### PR TITLE
Migrate projects to make the NuGet compatible to .NET Standard 2.0

### DIFF
--- a/src/PiWeb.Volume.Core/PiWeb.Volume.Core.vcxproj
+++ b/src/PiWeb.Volume.Core/PiWeb.Volume.Core.vcxproj
@@ -17,6 +17,8 @@
     <RootNamespace>PiWebVolume</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectName>PiWeb.Volume.Core</ProjectName>
+    <IntDir>obj\$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)\..\bin\$(Configuration)\</OutDir>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/PiWeb.Volume.UI/PiWeb.Volume.UI.csproj
+++ b/src/PiWeb.Volume.UI/PiWeb.Volume.UI.csproj
@@ -2,38 +2,42 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
+    <Platforms>x64</Platforms>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
     <ProjectGuid>{990AFF9C-CA6F-4E61-8A67-C5C29184A0AC}</ProjectGuid>
     <OutputType>WinExe</OutputType>
     <RootNamespace>Zeiss.IMT.PiWeb.Volume.UI</RootNamespace>
     <AssemblyName>PiWeb.Volume.UI</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <OutputPath>$(SolutionDir)\..\bin\$(Configuration\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>..\x64\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32bit>false</Prefer32bit>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\x64\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32bit>false</Prefer32bit>
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32bit>false</Prefer32bit>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="CommonServiceLocator, Version=2.0.2.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0">

--- a/src/PiWeb.Volume.sln
+++ b/src/PiWeb.Volume.sln
@@ -14,22 +14,22 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PiWeb.Volume.UI", "PiWeb.Vo
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Debug|x64 = Debug|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{7BC35A03-B0E0-4182-80E1-A50A2CB5A5E3}.Debug|Any CPU.ActiveCfg = Debug|x64
-		{7BC35A03-B0E0-4182-80E1-A50A2CB5A5E3}.Debug|Any CPU.Build.0 = Debug|x64
-		{7BC35A03-B0E0-4182-80E1-A50A2CB5A5E3}.Release|Any CPU.ActiveCfg = Release|x64
-		{7BC35A03-B0E0-4182-80E1-A50A2CB5A5E3}.Release|Any CPU.Build.0 = Release|x64
-		{EE00A737-6B2B-4EE2-800F-21C8E7CB30E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{EE00A737-6B2B-4EE2-800F-21C8E7CB30E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EE00A737-6B2B-4EE2-800F-21C8E7CB30E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{EE00A737-6B2B-4EE2-800F-21C8E7CB30E5}.Release|Any CPU.Build.0 = Release|Any CPU
-		{990AFF9C-CA6F-4E61-8A67-C5C29184A0AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{990AFF9C-CA6F-4E61-8A67-C5C29184A0AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{990AFF9C-CA6F-4E61-8A67-C5C29184A0AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{990AFF9C-CA6F-4E61-8A67-C5C29184A0AC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EE00A737-6B2B-4EE2-800F-21C8E7CB30E5}.Release|x64.ActiveCfg = Release|x64
+		{EE00A737-6B2B-4EE2-800F-21C8E7CB30E5}.Release|x64.Build.0 = Release|x64
+		{EE00A737-6B2B-4EE2-800F-21C8E7CB30E5}.Debug|x64.ActiveCfg = Debug|x64
+		{EE00A737-6B2B-4EE2-800F-21C8E7CB30E5}.Debug|x64.Build.0 = Debug|x64
+		{7BC35A03-B0E0-4182-80E1-A50A2CB5A5E3}.Release|x64.ActiveCfg = Release|x64
+		{7BC35A03-B0E0-4182-80E1-A50A2CB5A5E3}.Release|x64.Build.0 = Release|x64
+		{7BC35A03-B0E0-4182-80E1-A50A2CB5A5E3}.Debug|x64.ActiveCfg = Debug|x64
+		{7BC35A03-B0E0-4182-80E1-A50A2CB5A5E3}.Debug|x64.Build.0 = Debug|x64
+		{990AFF9C-CA6F-4E61-8A67-C5C29184A0AC}.Release|x64.ActiveCfg = Release|x64
+		{990AFF9C-CA6F-4E61-8A67-C5C29184A0AC}.Release|x64.Build.0 = Release|x64
+		{990AFF9C-CA6F-4E61-8A67-C5C29184A0AC}.Debug|x64.ActiveCfg = Debug|x64
+		{990AFF9C-CA6F-4E61-8A67-C5C29184A0AC}.Debug|x64.Build.0 = Debug|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/PiWeb.Volume/PiWeb.Volume.csproj
+++ b/src/PiWeb.Volume/PiWeb.Volume.csproj
@@ -1,90 +1,51 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{EE00A737-6B2B-4EE2-800F-21C8E7CB30E5}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <Platforms>x64</Platforms>
+    
     <RootNamespace>Zeiss.IMT.PiWeb.Volume</RootNamespace>
-    <AssemblyName>PiWeb.Volume</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <SignAssembly>true</SignAssembly>
-    <WarningLevel>4</WarningLevel>
-    <UseVSHostingProcess>false</UseVSHostingProcess>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworkProfile />
-  </PropertyGroup>
-  <PropertyGroup>
-    <!--Looks like there is a visual studio bug with the result that some macros like $(ProjectDir) return blank. As a workaround $(MSBuildProjectDirectory) can be used. -->
-    <PreBuildEvent>
-    </PreBuildEvent>
-  </PropertyGroup>
-  <PropertyGroup>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <OutputPath>$(SolutionDir)\..\bin\$(Configuration)\</OutputPath>
+    <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Volume.snk</AssemblyOriginatorKeyFile>
+    <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>..\x64\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG</DefineConstants>
-    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <UseVSHostingProcess>false</UseVSHostingProcess>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DocumentationFile>$(SolutionDir)\..\bin\$(Configuration)\PiWeb.Volume.xml</DocumentationFile>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
-    <OutputPath>..\x64\Release\</OutputPath>
-    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
-    <DocumentationFile>..\x64\Release\PiWeb.Volume.xml</DocumentationFile>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <UseVSHostingProcess>false</UseVSHostingProcess>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <Optimize>true</Optimize>
+  
+  <PropertyGroup>
+    <IsPackable>true</IsPackable>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+
+    <PackageId>Zeiss.IMT.PiWeb.Volume</PackageId>
+    <Title>Carl Zeiss PiWeb Volume API</Title>
+    <Authors>Carl Zeiss IZfM Dresden</Authors>
+    <Description>The Carl Zeiss PiWeb-Volume API allows to compress and store volumemetric data for visualization in PiWeb.</Description>
+    <PackageProjectUrl>https://github.com/ZEISS-PiWeb/PiWeb-Volume</PackageProjectUrl>
+    <PackageLicenseUrl>https://github.com/ZEISS-PiWeb/PiWeb-Volume/blob/master/LICENSE.md</PackageLicenseUrl>
+    <PackageIconUrl>https://github.com/ZEISS-PiWeb/PiWeb-Volume/raw/master/logo6464.png</PackageIconUrl>
+    <PackageTags>Carl Zeiss PiWeb Volume</PackageTags>
+    <PackageReleaseNotes>NuGet package is now .NET Standard 2.0 compatible</PackageReleaseNotes>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <Copyright>© Carl Zeiss IZfM Dresden</Copyright>
+    <VersionPrefix>1.1.0</VersionPrefix>
   </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.IO.Compression" />
-    <Reference Include="System.XML" />
+    <ProjectReference Include="..\PiWeb.Volume.Core\PiWeb.Volume.Core.vcxproj" />
   </ItemGroup>
+  
   <ItemGroup>
-    <Compile Include="CompressedVolume.cs" />
-    <Compile Include="DataTypeId.cs" />
-    <Compile Include="DirectionMap.cs" />
-    <Compile Include="Interop\InteropStream.cs" />
-    <Compile Include="Interop\InteropSliceWriter.cs" />
-    <Compile Include="Property.cs" />
-    <Compile Include="SliceStreamReader.cs" />
-    <Compile Include="SliceReader.cs" />
-    <Compile Include="Constants.cs" />
-    <Compile Include="Interop\InteropSliceReader.cs" />
-    <Compile Include="PreviewCreator.cs" />
-    <Compile Include="Direction.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="ReaderWriterExtensions.cs" />
-    <Compile Include="ResourceManager.cs" />
-    <Compile Include="FullVolumeWriter.cs" />
-    <Compile Include="UncompressedVolume.cs" />
-    <Compile Include="VolumeSlice.cs" />
-    <Compile Include="VolumeSliceProgress.cs" />
-    <Compile Include="VolumeSliceRange.cs" />
-    <Compile Include="VolumeSliceCollection.cs" />
-    <Compile Include="VolumeSliceRangeCollector.cs" />
-    <Compile Include="StreamWrapper.cs" />
-    <Compile Include="Volume.cs" />
-    <Compile Include="VolumeCompressionOptions.cs" />
-    <Compile Include="VolumeError.cs" />
-    <Compile Include="VolumeException.cs" />
-    <Compile Include="VolumeMetadata.cs" />
-    <Compile Include="VolumeSliceRangeDefinition.cs" />
-    <Compile Include="VolumeCompressionState.cs" />
-    <Compile Include="VolumeSliceRangeDefinitionExtensions.cs" />
     <None Include="Volume.snk" />
-  </ItemGroup>
-  <ItemGroup>
+
     <EmbeddedResource Include="Volume.de.resx">
       <DependentUpon>Volume.cs</DependentUpon>
     </EmbeddedResource>
@@ -92,5 +53,10 @@
       <DependentUpon>Volume.cs</DependentUpon>
     </EmbeddedResource>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+
+  <ItemGroup>
+    <None Include="$(SolutionDir)\PiWeb.Volume.Core\lib\*.dll" Pack="true" PackagePath="runtimes\win-x64\native\" Visible="false" />
+    <None Include="$(SolutionDir)\..\bin\$(Configuration)\PiWeb.Volume.Core.dll" Pack="true" PackagePath="runtimes\win-x64\native\" Visible="false" />
+  </ItemGroup>
+
 </Project>

--- a/src/PiWeb.Volume/Zeiss.IMT.PiWeb.Volume.1.0.0.targets
+++ b/src/PiWeb.Volume/Zeiss.IMT.PiWeb.Volume.1.0.0.targets
@@ -1,9 +1,0 @@
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>
-    <NativeLibs Include="$(MSBuildThisFileDirectory)**\*.dll" />
-    <None Include="@(NativeLibs)">
-      <Link>%(RecursiveDir)%(FileName)%(Extension)</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-</Project>


### PR DESCRIPTION
The goal is to make it possible to also consume this NuGet package from .NET Core projects.

Included changes:
* Updated the solution configuration to specify x64 architecture instead of AnyCPU. (since only Windows x64 binaries are included)
* For simplification all projects do now compile into the same bin folder.
* The `PiWeb.Volume` project does now use SDK style project format and is targeting .NET Standard 2.0.
* The project model is now used to pack the NuGet file when building the `PiWeb.Volume` project.
* The summary field has been removed from the NuGet, since it has been deprecated.