### PR TITLE
chore: Upgrade NuGet dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Check path
+      run: echo ${{ github.workspace }} 
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
@@ -31,4 +33,4 @@ jobs:
     - name: Build and restore
       run: msbuild -restore -p:Configuration=Release
     - name: Test
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet test --no-build --verbosity normal ${{ github.workspace }}\bin\Release\PiWeb.Volume.Tests.dll

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,4 +1,4 @@
-name: .NET
+name: Build and Test
 
 on:
   push:
@@ -10,10 +10,12 @@ defaults:
   run:
     working-directory: src
 
+
+
 jobs:
   build:
 
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v2
@@ -21,9 +23,12 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 6.0.x
-    - name: Restore dependencies
-      run: dotnet restore
-    - name: Build
-      run: dotnet build --no-restore
+    - name: Setup MSBuild
+      uses: microsoft/setup-msbuild@v1.1
+      with:
+        # The preferred processor architecture of MSBuild. Can be either "x86" or "x64". "x64" is only available from Visual Studio version 17.0 and later.
+        msbuild-architecture: x64
+    - name: Build and restore
+      run: msbuild -restore -p:Configuration=Release
     - name: Test
       run: dotnet test --no-build --verbosity normal

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,29 @@
+name: .NET
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ develop ]
+
+defaults:
+  run:
+    working-directory: src
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore
+    - name: Test
+      run: dotnet test --no-build --verbosity normal

--- a/src/PiWeb.Volume.Compare/PiWeb.Volume.Compare.csproj
+++ b/src/PiWeb.Volume.Compare/PiWeb.Volume.Compare.csproj
@@ -1,38 +1,41 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <Platforms>x64</Platforms>
-        <OutputType>WinExe</OutputType>
-        <RootNamespace>Zeiss.PiWeb.Volume.Compare</RootNamespace>
-        <TargetFramework>net6.0-windows</TargetFramework>
-        <OutputPath>$(SolutionDir)\..\bin\$(Configuration)\</OutputPath>
-        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-        <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
-        <AssemblyTitle>PiWeb.Volume.Compare</AssemblyTitle>
-        <Product>PiWeb.Volume.Compare</Product>
-        <UseWPF>true</UseWPF>
-        <IsPackable>false</IsPackable>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <Platforms>x64</Platforms>
+    <LangVersion>9</LangVersion>
+    <AssemblyName>PiWeb.Volume.Compare</AssemblyName>
+    <RootNamespace>Zeiss.PiWeb.Volume.Compare</RootNamespace>
+    <Copyright>Copyright © 2020 Carl Zeiss Industrielle Messtechnik GmbH</Copyright>
+    <Company>Carl Zeiss Industrielle Messtechnik GmbH</Company>
+    <Authors>$(Company)</Authors>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputType>WinExe</OutputType>
+    <UseWPF>true</UseWPF>
+    <IsPackable>false</IsPackable>
+    <OutputPath>$(SolutionDir)\..\bin\$(Configuration)\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+  </PropertyGroup>
 
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
-      <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
 
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
-      <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\PiWeb.Volume.Convert\PiWeb.Volume.Convert.csproj" />
-      <ProjectReference Include="..\PiWeb.Volume.UI\PiWeb.Volume.UI.csproj" />
-      <ProjectReference Include="..\PiWeb.Volume\PiWeb.Volume.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\PiWeb.Volume.Convert\PiWeb.Volume.Convert.csproj" />
+    <ProjectReference Include="..\PiWeb.Volume.UI\PiWeb.Volume.UI.csproj" />
+    <ProjectReference Include="..\PiWeb.Volume\PiWeb.Volume.csproj" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <PackageReference Include="Extended.Wpf.Toolkit" Version="4.2.0" NoWarn="NU1701" />
-      <PackageReference Include="MvvmLightLibs" Version="5.4.1.1" NoWarn="NU1701" />
-      <PackageReference Include="Unity" Version="5.11.10" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Extended.Wpf.Toolkit" Version="4.2.0" NoWarn="NU1701" />
+    <PackageReference Include="MvvmLightLibs" Version="5.4.1.1" NoWarn="NU1701" />
+    <PackageReference Include="Unity" Version="5.11.10" />
+  </ItemGroup>
 
 </Project>

--- a/src/PiWeb.Volume.Compare/PiWeb.Volume.Compare.csproj
+++ b/src/PiWeb.Volume.Compare/PiWeb.Volume.Compare.csproj
@@ -30,9 +30,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Extended.Wpf.Toolkit" Version="4.0.1" NoWarn="NU1701" />
+      <PackageReference Include="Extended.Wpf.Toolkit" Version="4.2.0" NoWarn="NU1701" />
       <PackageReference Include="MvvmLightLibs" Version="5.4.1.1" NoWarn="NU1701" />
-      <PackageReference Include="Unity" Version="5.11.1" />
+      <PackageReference Include="Unity" Version="5.11.10" />
     </ItemGroup>
 
 </Project>

--- a/src/PiWeb.Volume.Convert/PiWeb.Volume.Convert.csproj
+++ b/src/PiWeb.Volume.Convert/PiWeb.Volume.Convert.csproj
@@ -1,29 +1,30 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <Platforms>x64</Platforms>
-        <RootNamespace>Zeiss.PiWeb.Volume.Convert</RootNamespace>
-        <TargetFramework>net6.0</TargetFramework>
-        <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-        <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-        <OutputPath>$(SolutionDir)\..\bin\$(Configuration)\</OutputPath>
-        <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
-        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-        <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
-        <PackageVersion>1.0.0</PackageVersion>
-        <LangVersion>9</LangVersion>
-        <AssemblyVersion>1.0.0.0</AssemblyVersion>
-        <FileVersion>1.0.0.0</FileVersion>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Platforms>x64</Platforms>
+    <LangVersion>9</LangVersion>
+    <AssemblyName>PiWeb.Volume.Convert</AssemblyName>
+    <RootNamespace>Zeiss.PiWeb.Volume.Convert</RootNamespace>
+    <Copyright>Copyright © 2020 Carl Zeiss Industrielle Messtechnik GmbH</Copyright>
+    <Company>Carl Zeiss Industrielle Messtechnik GmbH</Company>
+    <Authors>$(Company)</Authors>
+    <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
+    <OutputPath>$(SolutionDir)\..\bin\$(Configuration)\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\PiWeb.Volume\PiWeb.Volume.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(SolutionDir)\PiWeb.Volume\PiWeb.Volume.csproj" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <PackageReference Include="System.Buffers" Version="4.5.1" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
+  </ItemGroup>
 
 </Project>

--- a/src/PiWeb.Volume.Convert/PiWeb.Volume.Convert.csproj
+++ b/src/PiWeb.Volume.Convert/PiWeb.Volume.Convert.csproj
@@ -13,7 +13,7 @@
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
         <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
         <PackageVersion>1.0.0</PackageVersion>
-        <LangVersion>8</LangVersion>
+        <LangVersion>9</LangVersion>
         <AssemblyVersion>1.0.0.0</AssemblyVersion>
         <FileVersion>1.0.0.0</FileVersion>
     </PropertyGroup>

--- a/src/PiWeb.Volume.Tests/PiWeb.Volume.Tests.csproj
+++ b/src/PiWeb.Volume.Tests/PiWeb.Volume.Tests.csproj
@@ -1,23 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <Platforms>x64</Platforms>
-        <RootNamespace>Zeiss.PiWeb.Volume.Tests</RootNamespace>
-        <TargetFramework>net6.0</TargetFramework>
-        <OutputPath>$(SolutionDir)\..\bin\$(Configuration)\</OutputPath>
-        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-        <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
-        <IsPackable>false</IsPackable>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Platforms>x64</Platforms>
+    <LangVersion>9</LangVersion>
+    <RootNamespace>Zeiss.PiWeb.Volume.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <OutputPath>$(SolutionDir)\..\bin\$(Configuration)\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-        <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
-        <PackageReference Include="NUnit" Version="3.13.2" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)\PiWeb.Volume\PiWeb.Volume.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(SolutionDir)\PiWeb.Volume\PiWeb.Volume.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/PiWeb.Volume.Tests/PiWeb.Volume.Tests.csproj
+++ b/src/PiWeb.Volume.Tests/PiWeb.Volume.Tests.csproj
@@ -11,9 +11,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-        <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-        <PackageReference Include="NUnit" Version="3.12.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+        <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+        <PackageReference Include="NUnit" Version="3.13.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/PiWeb.Volume.Tests/PiWeb.Volume.Tests.csproj
+++ b/src/PiWeb.Volume.Tests/PiWeb.Volume.Tests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
     <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PiWeb.Volume.UI/PiWeb.Volume.UI.csproj
+++ b/src/PiWeb.Volume.UI/PiWeb.Volume.UI.csproj
@@ -1,36 +1,43 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net6.0-windows</TargetFramework>
-        <Platforms>x64</Platforms>
-        <RootNamespace>Zeiss.PiWeb.Volume.UI</RootNamespace>
-        <OutputPath>$(SolutionDir)\..\bin\$(Configuration)\</OutputPath>
-        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-        <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
-        <AssemblyTitle>PiWeb.Volume.UI</AssemblyTitle>
-        <Product>PiWeb.Volume.UI</Product>
-        <UseWPF>true</UseWPF>
-        <IsPackable>false</IsPackable>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <Platforms>x64</Platforms>
+    <LangVersion>9</LangVersion>
+    <AssemblyName>PiWeb.Volume.UI</AssemblyName>
+    <RootNamespace>Zeiss.PiWeb.Volume.UI</RootNamespace>
+    <Copyright>Copyright © 2020 Carl Zeiss Industrielle Messtechnik GmbH</Copyright>
+    <Company>Carl Zeiss Industrielle Messtechnik GmbH</Company>
+    <Authors>$(Company)</Authors>
+    <UseWPF>true</UseWPF>
+    <IsPackable>false</IsPackable>
+    <OutputPath>$(SolutionDir)\..\bin\$(Configuration)\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+  </PropertyGroup>
 
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    </PropertyGroup>
-    <ItemGroup>
-        <PackageReference Include="MvvmLightLibs" Version="5.4.1.1" NoWarn="NU1701" />
-        <PackageReference Include="System.Reactive" Version="4.4.1" NoWarn="NU1701" />
-        <PackageReference Include="Extended.Wpf.Toolkit" Version="4.2.0" NoWarn="NU1701" />
-    </ItemGroup>
-    <ItemGroup>
-        <Resource Include="Effects\*.ps" />
-        <Resource Include="Resources\**\*.png" />
-    </ItemGroup>
-    <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)\PiWeb.Volume\PiWeb.Volume.csproj" />
-        <ProjectReference Include="$(SolutionDir)\PiWeb.Volume.Convert\PiWeb.Volume.Convert.csproj" />
-    </ItemGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="MvvmLightLibs" Version="5.4.1.1" NoWarn="NU1701" />
+    <PackageReference Include="System.Reactive" Version="4.4.1" NoWarn="NU1701" />
+    <PackageReference Include="Extended.Wpf.Toolkit" Version="4.2.0" NoWarn="NU1701" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <Resource Include="Effects\*.ps" />
+    <Resource Include="Resources\**\*.png" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="$(SolutionDir)\PiWeb.Volume\PiWeb.Volume.csproj" />
+    <ProjectReference Include="$(SolutionDir)\PiWeb.Volume.Convert\PiWeb.Volume.Convert.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/PiWeb.Volume.UI/PiWeb.Volume.UI.csproj
+++ b/src/PiWeb.Volume.UI/PiWeb.Volume.UI.csproj
@@ -21,8 +21,8 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="MvvmLightLibs" Version="5.4.1.1" NoWarn="NU1701" />
-        <PackageReference Include="System.Reactive" Version="4.2.0" NoWarn="NU1701" />
-        <PackageReference Include="Extended.Wpf.Toolkit" Version="4.0.1" NoWarn="NU1701" />
+        <PackageReference Include="System.Reactive" Version="4.4.1" NoWarn="NU1701" />
+        <PackageReference Include="Extended.Wpf.Toolkit" Version="4.2.0" NoWarn="NU1701" />
     </ItemGroup>
     <ItemGroup>
         <Resource Include="Effects\*.ps" />

--- a/src/PiWeb.Volume.Viewer/PiWeb.Volume.Viewer.csproj
+++ b/src/PiWeb.Volume.Viewer/PiWeb.Volume.Viewer.csproj
@@ -20,8 +20,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MvvmLightLibs" Version="5.4.1.1" NoWarn="NU1701" />
-    <PackageReference Include="System.Reactive" Version="4.2.0" />
-    <PackageReference Include="Unity" Version="5.11.1" />
+    <PackageReference Include="System.Reactive" Version="4.4.1" />
+    <PackageReference Include="Unity" Version="5.11.10" />
   </ItemGroup>
   <ItemGroup>
     <Resource Include="Effects\*.ps" />

--- a/src/PiWeb.Volume.Viewer/PiWeb.Volume.Viewer.csproj
+++ b/src/PiWeb.Volume.Viewer/PiWeb.Volume.Viewer.csproj
@@ -1,35 +1,41 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  
   <PropertyGroup>
     <Platforms>x64</Platforms>
     <OutputType>WinExe</OutputType>
+    <AssemblyName>PiWeb.Volume.Viewer</AssemblyName>
     <RootNamespace>Zeiss.PiWeb.Volume.Viewer</RootNamespace>
     <TargetFramework>net6.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <IsPackable>false</IsPackable>
     <OutputPath>$(SolutionDir)\..\bin\$(Configuration)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
-    <AssemblyTitle>PiWeb.Volume.Viewer</AssemblyTitle>
-    <Product>PiWeb.Volume.Viewer</Product>
-    <UseWPF>true</UseWPF>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
+  
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+  
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+    
   <ItemGroup>
     <PackageReference Include="MvvmLightLibs" Version="5.4.1.1" NoWarn="NU1701" />
     <PackageReference Include="System.Reactive" Version="4.4.1" />
     <PackageReference Include="Unity" Version="5.11.10" />
   </ItemGroup>
+      
   <ItemGroup>
     <Resource Include="Effects\*.ps" />
     <Resource Include="Resources\**\*.png" />
   </ItemGroup>
+  
   <ItemGroup>
     <ProjectReference Include="$(SolutionDir)\PiWeb.Volume\PiWeb.Volume.csproj" />
     <ProjectReference Include="$(SolutionDir)\PiWeb.Volume.Convert\PiWeb.Volume.Convert.csproj" />
     <ProjectReference Include="$(SolutionDir)\PiWeb.Volume.UI\PiWeb.Volume.UI.csproj" />
   </ItemGroup>
+
 </Project>

--- a/src/PiWeb.Volume/PiWeb.Volume.csproj
+++ b/src/PiWeb.Volume/PiWeb.Volume.csproj
@@ -39,7 +39,7 @@
     <PackageTags>Carl Zeiss PiWeb Volume</PackageTags>
     <PackageReleaseNotes>Made the volume array pool public.</PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <Version>2.0.0</Version>
     <RepositoryUrl>https://github.com/ZEISS-PiWeb/PiWeb-MeshModel.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>

--- a/src/PiWeb.Volume/PiWeb.Volume.csproj
+++ b/src/PiWeb.Volume/PiWeb.Volume.csproj
@@ -1,47 +1,45 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Platforms>x64</Platforms>
-    <RootNamespace>Zeiss.PiWeb.Volume</RootNamespace>
     <TargetFramework>net6.0</TargetFramework>
+    <Platforms>x64</Platforms>
+    <LangVersion>9</LangVersion>
+    <AssemblyName>PiWeb.Volume</AssemblyName>
+    <RootNamespace>Zeiss.PiWeb.Volume</RootNamespace>
+    <Copyright>Copyright © 2020 Carl Zeiss Industrielle Messtechnik GmbH</Copyright>
+    <Company>Carl Zeiss Industrielle Messtechnik GmbH</Company>
+    <Authors>$(Company)</Authors>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <OutputPath>$(SolutionDir)\..\bin\$(Configuration)\</OutputPath>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
+    <OutputPath>$(SolutionDir)\..\bin\$(Configuration)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
-    <PackageVersion>2.0.0</PackageVersion>
-    <LangVersion>9</LangVersion>
-    <AssemblyVersion>2.0.0</AssemblyVersion>
-    <FileVersion>2.0.0</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <DocumentationFile>$(SolutionDir)\..\bin\$(Configuration)\PiWeb.Volume.xml</DocumentationFile>
+    <DocumentationFile>bin\$(Configuration)\PiWeb.Volume.xml</DocumentationFile>
   </PropertyGroup>
 
-  <PropertyGroup>
+  <PropertyGroup Label="NuGet package specifications">
     <IsPackable>true</IsPackable>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageId>Zeiss.PiWeb.Volume</PackageId>
     <ProductName>PiWeb Volume Library</ProductName>
-    <Title>Carl Zeiss PiWeb Volume API</Title>
-    <Copyright>Copyright © 2020 Carl Zeiss Industrielle Messtechnik GmbH</Copyright>
-    <Company>Carl Zeiss Industrielle Messtechnik GmbH</Company>
-    <Authors>$(Company)</Authors>
-    <Description>The Carl Zeiss PiWeb-Volume API allows to compress and store volumemetric data for visualization in PiWeb.</Description>
-    <PackageProjectUrl>https://github.com/ZEISS-PiWeb/PiWeb-Volume</PackageProjectUrl>
+    <Description>
+      The Carl Zeiss PiWeb-Volume API allows to compress and store
+      volumemetric data for visualization in PiWeb.
+    </Description>
+    <PackageId>Zeiss.PiWeb.Volume</PackageId>
+    <Version>2.0.0</Version>
     <PackageIcon>logo_128x128.png</PackageIcon>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
-    <PackageTags>Carl Zeiss PiWeb Volume</PackageTags>
-    <PackageReleaseNotes>Made the volume array pool public.</PackageReleaseNotes>
+    <PackageProjectUrl>https://github.com/ZEISS-PiWeb/PiWeb-Volume</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <Version>2.0.0</Version>
-    <RepositoryUrl>https://github.com/ZEISS-PiWeb/PiWeb-MeshModel.git</RepositoryUrl>
+    <RepositoryUrl>https://github.com/ZEISS-PiWeb/PiWeb-Volume.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
+    <PackageTags>Carl Zeiss PiWeb Volume</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
@@ -49,7 +47,6 @@
   </ItemGroup>
 
   <ItemGroup>
-
     <EmbeddedResource Include="Volume.de.resx">
       <DependentUpon>Volume.cs</DependentUpon>
     </EmbeddedResource>
@@ -60,7 +57,7 @@
 
   <ItemGroup>
     <None Include="$(SolutionDir)\PiWeb.Volume.Core\lib\*.dll" Pack="true" PackagePath="runtimes\win-x64\native\" Visible="false" />
-    <None Include="$(SolutionDir)\..\bin\$(Configuration)\PiWeb.Volume.Core.dll" Pack="true" PackagePath="runtimes\win-x64\native\" Visible="false" />
+    <None Include="$(SolutionDir)\PiWeb.Volume.Core\bin\$(Configuration)\PiWeb.Volume.Core.dll" Pack="true" PackagePath="runtimes\win-x64\native\" Visible="false" />
     <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="LICENSE.txt"/>
     <None Include="..\..\gfx\logo_128x128.png" Pack="true" PackagePath="logo_128x128.png"/>
     <None Include="..\..\third_party_notices\third_party_notices.txt"/>


### PR DESCRIPTION
+ bumps Extended.Wpf.Toolkit from 4.0.1 to 4.2.0
+ bumps Unity from 5.11.1 to 5.11.10
+ bumps Microsoft.NET.Test.Sdk from 0.12.1 to 0.13.1
+ bumps NUnit from 3.12.0 to 3.13.2
+ bumps System.Reactive from 4.2.0 to 4.4.1
+ adds build pipeline 