### PR TITLE
feat: add the possibility to extract partial slices

### DIFF
--- a/src/PiWeb.Volume.Tests/Block/BlockVolumeSliceRangeCollectorTest.cs
+++ b/src/PiWeb.Volume.Tests/Block/BlockVolumeSliceRangeCollectorTest.cs
@@ -1,0 +1,114 @@
+#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Volume.Tests.Block;
+
+#region usings
+
+using System;
+using System.IO;
+using NUnit.Framework;
+using Zeiss.PiWeb.Volume.Block;
+
+#endregion
+
+[TestFixture]
+public class BlockVolumeSliceRangeCollectorTest
+{
+	#region members
+
+	private CompressedVolume _Volume;
+
+	//The volume is compressed and has compression artifacts. This is the estimated PSNR for the test volume.
+	private const int Tolerance = 16;
+
+	#endregion
+
+	#region methods
+
+	[OneTimeSetUp]
+	public void SetUpTests()
+	{
+		using var stream = File.OpenRead( Path.Combine( Paths.TestData, "high_noise_volume.volx" ) );
+		_Volume = Volume.Load( stream );
+
+		Assert.That( _Volume, Is.InstanceOf<BlockVolume>() );
+		Assert.That( _Volume.Metadata.SizeX, Is.EqualTo( BlockVolume.N2 ) );
+		Assert.That( _Volume.Metadata.SizeY, Is.EqualTo( BlockVolume.N2 ) );
+		Assert.That( _Volume.Metadata.SizeZ, Is.EqualTo( BlockVolume.N2 ) );
+	}
+
+	[Test]
+	public void Test_Get_Single_Full_Slice( [Values] Direction direction, [Values( 0, 8, 16, 32, 48 )] int index )
+	{
+		var slice = _Volume.GetSlice( new VolumeSliceDefinition( direction, (ushort)index ) );
+		AssertSliceValues( slice, index );
+	}
+
+	public static VolumeRange[] Ranges =
+	[
+		new VolumeRange( 0, 7 ),
+		new VolumeRange( 0, 15 ),
+		new VolumeRange( 4, 12 ),
+		new VolumeRange( 4, 60 ),
+		new VolumeRange( 50, 63 ),
+		new VolumeRange( 56, 63 )
+	];
+
+	[Test]
+	public void Test_Get_Single_Slice_With_ROI(
+		[Values] Direction direction,
+		[Values( 0, 8, 16, 32, 48 )] int index,
+		[ValueSource( nameof( Ranges ) )] VolumeRange u,
+		[ValueSource( nameof( Ranges ) )] VolumeRange v )
+	{
+		var region = new VolumeRegion( u, v );
+		var slice = _Volume.GetSlice( new VolumeSliceDefinition( direction, (ushort)index, region ) );
+		AssertSliceValues( slice, index, region );
+	}
+
+	[Test]
+	public void Test_Get_Multiple_Slices_With_ROI(
+		[Values] Direction direction,
+		[Values( 0, 8, 16, 32, 48 )] int index,
+		[Values( 1, 8, 12 )] int count,
+		[ValueSource( nameof( Ranges ) )] VolumeRange u,
+		[ValueSource( nameof( Ranges ) )] VolumeRange v )
+	{
+		var region = new VolumeRegion( u, v );
+		var rangeDefinition = new VolumeSliceRangeDefinition( direction, (ushort)index, (ushort)( index + count ), region );
+		var range = _Volume.GetSliceRange( rangeDefinition );
+
+		foreach( var slice in range )
+			AssertSliceValues( slice, slice.Index, region );
+	}
+
+	private static void AssertSliceValues( VolumeSlice slice, int index, VolumeRegion? region = null )
+	{
+		for( ushort b = 0; b < BlockVolume.N2; b++ )
+		for( ushort a = 0; a < BlockVolume.N2; a++ )
+		{
+			if( region.HasValue && ( !region.Value.U.Contains( a ) || !region.Value.V.Contains( b ) ) )
+				continue;
+
+			var value = slice.Data[ a + b * BlockVolume.N2 ];
+			var expectedValue = index % ( BlockVolume.N + 1 ) == 0 ||
+				a % ( BlockVolume.N + 1 ) == 0 ||
+				b % ( BlockVolume.N + 1 ) == 0
+					? byte.MaxValue
+					: byte.MinValue;
+
+			var difference = Math.Abs( value - expectedValue );
+			Assert.That( difference, Is.LessThanOrEqualTo( Tolerance ) );
+		}
+	}
+
+	#endregion
+}

--- a/src/PiWeb.Volume.Tests/Block/DiscreteCosineTransformTest.cs
+++ b/src/PiWeb.Volume.Tests/Block/DiscreteCosineTransformTest.cs
@@ -8,7 +8,7 @@
 
 #endregion
 
-namespace Zeiss.PiWeb.Volume.Tests;
+namespace Zeiss.PiWeb.Volume.Tests.Block;
 
 #region usings
 

--- a/src/PiWeb.Volume.Tests/Performance/CreatePreviewTest.cs
+++ b/src/PiWeb.Volume.Tests/Performance/CreatePreviewTest.cs
@@ -11,7 +11,7 @@ namespace Zeiss.PiWeb.Volume.Tests.Performance
 	{
 		#region members
 
-		private static readonly string SamplePath = Path.Combine( Paths.TestData, "testcube_singledirection.volx" );
+		private static readonly string SamplePath = Path.Combine( Paths.TestData, "seatbelt_button.volx" );
 
 		private CompressedVolume _SampleCompressedVolume;
 		private UncompressedVolume _SampleDecompressedVolume;

--- a/src/PiWeb.Volume.Tests/Performance/DecompressVolumeTest.cs
+++ b/src/PiWeb.Volume.Tests/Performance/DecompressVolumeTest.cs
@@ -11,7 +11,7 @@ namespace Zeiss.PiWeb.Volume.Tests.Performance
 	{
 		#region members
 
-		private static readonly string SamplePath = Path.Combine( Paths.TestData, "testcube_singledirection.volx" );
+		private static readonly string SamplePath = Path.Combine( Paths.TestData, "seatbelt_button.volx" );
 
 		private CompressedVolume _SampleCompressedVolume;
 

--- a/src/PiWeb.Volume.Tests/Performance/LoadVolumeTest.cs
+++ b/src/PiWeb.Volume.Tests/Performance/LoadVolumeTest.cs
@@ -25,7 +25,7 @@ namespace Zeiss.PiWeb.Volume.Tests.Performance
 	{
 		#region members
 
-		private static readonly string SamplePath = Path.Combine( Paths.TestData, "testcube_singledirection.volx" );
+		private static readonly string SamplePath = Path.Combine( Paths.TestData, "seatbelt_button.volx" );
 		private byte[] _VolumeData;
 
 		#endregion

--- a/src/PiWeb.Volume/VolumeRange.cs
+++ b/src/PiWeb.Volume/VolumeRange.cs
@@ -1,0 +1,45 @@
+#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Volume;
+
+/// <summary>
+/// Describes a range in voxel coordinates.
+/// </summary>
+/// <param name="Start">Inclusive start</param>
+/// <param name="End">Inclusive end</param>
+public readonly record struct VolumeRange( ushort Start, ushort End )
+{
+	#region methods
+
+	/// <summary>
+	/// Determines, whether this range contains <paramref name="value"/>.
+	/// </summary>
+	public bool Contains( ushort value )
+	{
+		return value >= Start && value <= End;
+	}
+
+	/// <summary>
+	/// Determines, whether there's an overlap between this range and <paramref name="other"/>.
+	/// </summary>
+	public bool Intersects( VolumeRange other )
+	{
+		return Start <= other.End && other.Start <= End;
+	}
+
+	/// <inheritdoc />
+	public override string ToString()
+	{
+		return $"[{Start}..{End}]";
+	}
+
+	#endregion
+}

--- a/src/PiWeb.Volume/VolumeRegion.cs
+++ b/src/PiWeb.Volume/VolumeRegion.cs
@@ -1,0 +1,17 @@
+#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Volume;
+
+/// <summary>
+/// Defines a region of interest inside a slice. The ranges <paramref name="U"/> and <paramref name="V"/> are projected
+/// to the slice direction.
+/// </summary>
+public readonly record struct VolumeRegion( VolumeRange U, VolumeRange V );

--- a/src/PiWeb.Volume/VolumeSliceDefinition.cs
+++ b/src/PiWeb.Volume/VolumeSliceDefinition.cs
@@ -13,34 +13,42 @@ namespace Zeiss.PiWeb.Volume
 	/// <summary>
 	/// Holds the properties that define a volume slice.
 	/// </summary>
-	public readonly struct VolumeSliceDefinition
+	public readonly record struct VolumeSliceDefinition
 	{
 		#region constructors
 
 		/// <summary>
 		/// Creates a decription of a volume slice.
 		/// </summary>
-		/// <param name="direction"></param>
-		/// <param name="index"></param>
-		public VolumeSliceDefinition( Direction direction, ushort index )
+		/// <param name="direction">The projection direction of the slice.</param>
+		/// <param name="index">The index of the slice in the volume.</param>
+		/// <param name="regionOfInterest">The region of interest inside the slice.</param>
+		public VolumeSliceDefinition( Direction direction, ushort index, VolumeRegion? regionOfInterest = null )
 		{
 			Direction = direction;
 			Index = index;
+			RegionOfInterest = regionOfInterest;
 		}
+
 
 		#endregion
 
 		#region properties
 
 		/// <summary>
-		/// Direction
+		/// Direction.
 		/// </summary>
 		public Direction Direction { get; }
 
 		/// <summary>
-		/// Slice index
+		/// Slice index.
 		/// </summary>
 		public ushort Index { get; }
+
+		/// <summary>
+		/// The region of interest in this slice.
+		/// </summary>
+		public VolumeRegion? RegionOfInterest { get; }
 
 		#endregion
 

--- a/src/PiWeb.Volume/VolumeSliceRangeDefinition.cs
+++ b/src/PiWeb.Volume/VolumeSliceRangeDefinition.cs
@@ -28,14 +28,16 @@ namespace Zeiss.PiWeb.Volume
 		/// <summary>
 		/// Initializes a new instance of the <see cref="VolumeSliceRangeDefinition"/> struct.
 		/// </summary>
-		/// <param name="direction"></param>
-		/// <param name="first">The first.</param>
-		/// <param name="last">The last.</param>
-		public VolumeSliceRangeDefinition( Direction direction, ushort first, ushort last )
+		/// <param name="direction">The projection direction of the slices.</param>
+		/// <param name="first">The first index of the slices in the volume.</param>
+		/// <param name="last">The last index of the slices in the volume.</param>
+		/// <param name="regionOfInterest">The region of interest inside the slices.</param>
+		public VolumeSliceRangeDefinition( Direction direction, ushort first, ushort last, VolumeRegion? regionOfInterest = null )
 		{
 			First = Math.Min( first, last );
 			Last = Math.Max( first, last );
 			Direction = direction;
+			RegionOfInterest = regionOfInterest;
 		}
 
 		#endregion
@@ -45,18 +47,20 @@ namespace Zeiss.PiWeb.Volume
 		/// <summary>
 		/// Gets the direction.
 		/// </summary>
-		/// <value>
-		/// The direction.
-		/// </value>
 		public Direction Direction { get; }
 
 		/// <summary>
-		/// Gets the inclusive first slice.
+		/// The region of interest inside the slices.
+		/// </summary>
+		public VolumeRegion? RegionOfInterest { get; }
+
+		/// <summary>
+		/// The inclusive first slice.
 		/// </summary>
 		public ushort First { get; }
 
 		/// <summary>
-		/// Gets the inclusive last slice.
+		/// The inclusive last slice.
 		/// </summary>
 		public ushort Last { get; }
 
@@ -84,7 +88,7 @@ namespace Zeiss.PiWeb.Volume
 		{
 			for( var i = First; i <= Last; i++ )
 			{
-				yield return new VolumeSliceDefinition( Direction, i );
+				yield return new VolumeSliceDefinition( Direction, i, RegionOfInterest );
 			}
 		}
 


### PR DESCRIPTION
Adds a new parameter `regionOfInterest` to the `VolumeSliceDefinition` which allows to decompress only partial slices from the compressed volume. The resulting buffer will still have the size of a full slice, bug values outside of the reagion of interest are not written during decompression.