### PR TITLE
Feature/jan/memory optimization

### DIFF
--- a/src/PiWeb.Volume.Tests/SmokeTests.cs
+++ b/src/PiWeb.Volume.Tests/SmokeTests.cs
@@ -129,6 +129,25 @@ namespace Zeiss.PiWeb.Volume.Tests
 		}
 
 		[Test, Explicit]
+		public void SaveSectionVolume()
+		{
+			using var stream = File.Create( "section_volume.uint8_scv" );
+
+			var volume = VolumeTestHelper.CreateSectionVolume();
+			SaveUncompressedVolume( stream, volume );
+		}
+
+		[Test, Explicit]
+		public void SavePartialVolume()
+		{
+			using var outputStream = File.Create( "partial_volume.uint8_scv" );
+
+			var sourceVolume = VolumeTestHelper.LoadUncompressedVolume( @"C:\Daten\Stecker.uint8_scv" );
+			var partialVolume = VolumeTestHelper.CreatePartialVolume( sourceVolume, new VolumeRange( 824, 855 ), new VolumeRange( 496, 527 ), new VolumeRange( 496, 527 ) );
+			SaveUncompressedVolume( outputStream, partialVolume );
+		}
+
+		[Test, Explicit]
 		public void CompareHighNoiseVolume( [Values( 25, 50, 75, 85, 90, 95, 100 )] int quality )
 		{
 			var original = VolumeTestHelper.CreateHighNoiseVolume();
@@ -169,7 +188,6 @@ namespace Zeiss.PiWeb.Volume.Tests
 			Console.WriteLine( @$"Quality {quality} mean: {noise.Value.Mean}" );
 			Console.WriteLine( @$"Quality {quality} q95: {noise.Value.Q95}" );
 		}
-
 
 
 		private static void SaveUncompressedVolume( Stream stream, UncompressedVolume volume )

--- a/src/PiWeb.Volume.UI/Components/SliceCrosshair.cs
+++ b/src/PiWeb.Volume.UI/Components/SliceCrosshair.cs
@@ -1,0 +1,67 @@
+namespace Zeiss.PiWeb.Volume.UI.Components;
+
+#region usings
+
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+
+#endregion
+
+public class SliceCrosshair : Control
+{
+	#region members
+
+	public static readonly DependencyProperty LastMousePositionProperty = DependencyProperty.Register(
+		nameof( LastMousePosition ), typeof( Point? ), typeof( SliceCrosshair ), new PropertyMetadata( default( Point? ) ) );
+
+	#endregion
+
+	#region properties
+
+	public Point? LastMousePosition
+	{
+		get => (Point?)GetValue( LastMousePositionProperty );
+		set => SetValue( LastMousePositionProperty, value );
+	}
+
+	#endregion
+
+	#region methods
+
+	protected override void OnMouseMove( MouseEventArgs e )
+	{
+		base.OnMouseMove( e );
+		var position = e.GetPosition( this );
+
+		SetCurrentValue( LastMousePositionProperty, new Point( Math.Round( position.X ), Math.Round( ActualHeight - position.Y ) ) );
+		InvalidateVisual();
+	}
+
+	protected override void OnMouseLeave( MouseEventArgs e )
+	{
+		base.OnMouseLeave( e );
+		SetCurrentValue( LastMousePositionProperty, null );
+		InvalidateVisual();
+	}
+
+	protected override void OnRender( DrawingContext drawingContext )
+	{
+		base.OnRender( drawingContext );
+
+		drawingContext.DrawRectangle( Brushes.Transparent, null, new Rect( 0, 0, ActualWidth, ActualHeight ) );
+
+		if( LastMousePosition is null )
+			return;
+
+		var pen = new Pen( Foreground, 1 );
+		var position = LastMousePosition.Value with { Y = ActualHeight - LastMousePosition.Value.Y };
+
+		drawingContext.DrawLine( pen, position with { X = 0 }, position with { X = ActualWidth } );
+		drawingContext.DrawLine( pen, position with { Y = 0 }, position with { Y = ActualHeight } );
+	}
+
+	#endregion
+}

--- a/src/PiWeb.Volume.UI/View/CodecView.xaml
+++ b/src/PiWeb.Volume.UI/View/CodecView.xaml
@@ -14,6 +14,10 @@
     <UniformGrid Columns="2">
         <TextBlock Margin="8" Text="Quality" />
         <xctk:IntegerUpDown Margin="8" Minimum="5" Maximum="100" Value="{Binding Path=Quality}" />
+        <TextBlock Margin="8" Text="QuantizationBase" />
+        <xctk:DoubleUpDown Margin="8" Minimum="4" Maximum="24" Value="{Binding Path=QuantizationBase}" />
+        <TextBlock Margin="8" Text="QuantizationGain" />
+        <xctk:DoubleUpDown Margin="8" Minimum="0.25" Maximum="4" Value="{Binding Path=QuantizationGain}" />
 
         <Button Margin="8" IsCancel="True" Content="Cancel" />
         <Button Margin="8"

--- a/src/PiWeb.Volume.UI/View/VolumeView.xaml
+++ b/src/PiWeb.Volume.UI/View/VolumeView.xaml
@@ -1,16 +1,16 @@
 <UserControl
-    d:DataContext="{d:DesignInstance viewModel:VolumeViewModel}"
-    d:DesignHeight="600"
-    d:DesignWidth="800"
-    mc:Ignorable="d"
     x:Class="Zeiss.PiWeb.Volume.UI.View.VolumeView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:components="clr-namespace:Zeiss.PiWeb.Volume.UI.Components"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:viewModel="clr-namespace:Zeiss.PiWeb.Volume.UI.ViewModel"
     xmlns:volume="clr-namespace:Zeiss.PiWeb.Volume;assembly=PiWeb.Volume"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    d:DataContext="{d:DesignInstance viewModel:VolumeViewModel}"
+    d:DesignHeight="600"
+    d:DesignWidth="800"
+    mc:Ignorable="d">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
@@ -39,13 +39,13 @@
 
             <!--  Title Size  -->
             <Border
-                BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
-                BorderThickness="0,0,0,1"
                 Grid.Row="0"
                 Margin="8,8,8,0"
-                VerticalAlignment="Center">
+                VerticalAlignment="Center"
+                BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
+                BorderThickness="0,0,0,1">
                 <StackPanel Margin="0,4" Orientation="Horizontal">
-                    <Image Source="/Resources/16px/page_size.png" Style="{StaticResource Icon}" />
+                    <Image Source="pack://application:,,,/PiWeb.Volume.UI;component/Resources/16px/page_size.png" Style="{StaticResource Icon}" />
                     <TextBlock Style="{StaticResource Header}">Size</TextBlock>
                 </StackPanel>
             </Border>
@@ -57,33 +57,33 @@
                     <HeaderedContentControl Header="X">
                         <TextBlock
                             HorizontalAlignment="Right"
-                            Text="{Binding Volume.Metadata.SizeX, StringFormat={}{0} Voxels}"
-                            VerticalAlignment="Center" />
+                            VerticalAlignment="Center"
+                            Text="{Binding Volume.Metadata.SizeX, StringFormat={}{0} Voxels}" />
                     </HeaderedContentControl>
                     <HeaderedContentControl Header="Y">
                         <TextBlock
                             HorizontalAlignment="Right"
-                            Text="{Binding Volume.Metadata.SizeY, StringFormat={}{0} Voxels}"
-                            VerticalAlignment="Center" />
+                            VerticalAlignment="Center"
+                            Text="{Binding Volume.Metadata.SizeY, StringFormat={}{0} Voxels}" />
                     </HeaderedContentControl>
                     <HeaderedContentControl Header="Z">
                         <TextBlock
                             HorizontalAlignment="Right"
-                            Text="{Binding Volume.Metadata.SizeZ, StringFormat={}{0} Voxels}"
-                            VerticalAlignment="Center" />
+                            VerticalAlignment="Center"
+                            Text="{Binding Volume.Metadata.SizeZ, StringFormat={}{0} Voxels}" />
                     </HeaderedContentControl>
                 </StackPanel>
             </DockPanel>
 
             <!--  Title Resolution  -->
             <Border
-                BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
-                BorderThickness="0,0,0,1"
                 Grid.Row="2"
                 Margin="8,0"
-                VerticalAlignment="Center">
+                VerticalAlignment="Center"
+                BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
+                BorderThickness="0,0,0,1">
                 <StackPanel Margin="0,4" Orientation="Horizontal">
-                    <Image Source="/Resources/16px/grid.png" Style="{StaticResource Icon}" />
+                    <Image Source="pack://application:,,,/PiWeb.Volume.UI;component/Resources/16px/grid.png" Style="{StaticResource Icon}" />
                     <TextBlock Style="{StaticResource Header}">Resolution</TextBlock>
                 </StackPanel>
             </Border>
@@ -94,33 +94,33 @@
                     <HeaderedContentControl Header="X">
                         <TextBlock
                             HorizontalAlignment="Right"
-                            Text="{Binding Volume.Metadata.ResolutionX, StringFormat={}{0:F3} mm}"
-                            VerticalAlignment="Center" />
+                            VerticalAlignment="Center"
+                            Text="{Binding Volume.Metadata.ResolutionX, StringFormat={}{0:F3} mm}" />
                     </HeaderedContentControl>
                     <HeaderedContentControl Header="Y">
                         <TextBlock
                             HorizontalAlignment="Right"
-                            Text="{Binding Volume.Metadata.ResolutionY, StringFormat={}{0:F3} mm}"
-                            VerticalAlignment="Center" />
+                            VerticalAlignment="Center"
+                            Text="{Binding Volume.Metadata.ResolutionY, StringFormat={}{0:F3} mm}" />
                     </HeaderedContentControl>
                     <HeaderedContentControl Header="Z">
                         <TextBlock
                             HorizontalAlignment="Right"
-                            Text="{Binding Volume.Metadata.ResolutionZ, StringFormat={}{0:F3} mm}"
-                            VerticalAlignment="Center" />
+                            VerticalAlignment="Center"
+                            Text="{Binding Volume.Metadata.ResolutionZ, StringFormat={}{0:F3} mm}" />
                     </HeaderedContentControl>
                 </StackPanel>
             </DockPanel>
 
             <!--  Title Properties  -->
             <Border
-                BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
-                BorderThickness="0,0,0,1"
                 Grid.Row="4"
                 Margin="8,0"
-                VerticalAlignment="Center">
+                VerticalAlignment="Center"
+                BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
+                BorderThickness="0,0,0,1">
                 <StackPanel Margin="0,4" Orientation="Horizontal">
-                    <Image Source="/Resources/16px/list_bullets.png" Style="{StaticResource Icon}" />
+                    <Image Source="pack://application:,,,/PiWeb.Volume.UI;component/Resources/16px/list_bullets.png" Style="{StaticResource Icon}" />
                     <TextBlock Style="{StaticResource Header}">Properties</TextBlock>
                 </StackPanel>
             </Border>
@@ -128,15 +128,15 @@
             <!--  Content Properties  -->
             <ScrollViewer
                 Grid.Row="5"
-                HorizontalScrollBarVisibility="Disabled"
                 Margin="8"
+                HorizontalScrollBarVisibility="Disabled"
                 VerticalScrollBarVisibility="Auto">
                 <ItemsControl ItemsSource="{Binding Volume.Metadata.Properties}">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
                             <Grid>
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition SharedSizeGroup="HeaderColumn" Width="Auto" />
+                                    <ColumnDefinition Width="Auto" SharedSizeGroup="HeaderColumn" />
                                     <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
                                 <TextBlock
@@ -145,8 +145,8 @@
                                     Text="{Binding Path=Name}" />
                                 <TextBlock
                                     Grid.Column="1"
-                                    HorizontalAlignment="Right"
                                     Margin="4"
+                                    HorizontalAlignment="Right"
                                     Text="{Binding Path=Value}" />
                             </Grid>
                         </DataTemplate>
@@ -158,45 +158,45 @@
 
             <!--  Title Compression  -->
             <Border
-                BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
-                BorderThickness="0,0,0,1"
                 Grid.Row="6"
                 Margin="8,0"
-                VerticalAlignment="Center">
+                VerticalAlignment="Center"
+                BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
+                BorderThickness="0,0,0,1">
                 <StackPanel Margin="0,4" Orientation="Horizontal">
-                    <Image Source="/Resources/16px/compress_table.png" Style="{StaticResource Icon}" />
+                    <Image Source="pack://application:,,,/PiWeb.Volume.UI;component/Resources/16px/compress_table.png" Style="{StaticResource Icon}" />
                     <TextBlock Style="{StaticResource Header}">Compression</TextBlock>
                 </StackPanel>
             </Border>
 
             <!--  Content Compression  -->
             <StackPanel
-                DockPanel.Dock="Right"
                 Grid.Row="7"
-                Margin="8">
+                Margin="8"
+                DockPanel.Dock="Right">
                 <HeaderedContentControl Header="Encoder">
                     <TextBlock
                         HorizontalAlignment="Right"
-                        Text="{Binding Volume.CompressionOptions.Encoder}"
-                        VerticalAlignment="Center" />
+                        VerticalAlignment="Center"
+                        Text="{Binding Volume.CompressionOptions.Encoder}" />
                 </HeaderedContentControl>
                 <HeaderedContentControl Header="Bitrate">
                     <TextBlock
                         HorizontalAlignment="Right"
-                        Text="{Binding Volume.CompressionOptions.Bitrate}"
-                        VerticalAlignment="Center" />
+                        VerticalAlignment="Center"
+                        Text="{Binding Volume.CompressionOptions.Bitrate}" />
                 </HeaderedContentControl>
                 <HeaderedContentControl Header="PixelFormat">
                     <TextBlock
                         HorizontalAlignment="Right"
-                        Text="{Binding Volume.CompressionOptions.PixelFormat}"
-                        VerticalAlignment="Center" />
+                        VerticalAlignment="Center"
+                        Text="{Binding Volume.CompressionOptions.PixelFormat}" />
                 </HeaderedContentControl>
                 <HeaderedContentControl Header="Options">
                     <TextBlock
                         HorizontalAlignment="Right"
-                        Text="{Binding Volume.CompressionOptions.EncoderOptions, Converter={StaticResource DictionaryToStringConverter}}"
-                        VerticalAlignment="Center" />
+                        VerticalAlignment="Center"
+                        Text="{Binding Volume.CompressionOptions.EncoderOptions, Converter={StaticResource DictionaryToStringConverter}}" />
                 </HeaderedContentControl>
 
             </StackPanel>
@@ -204,10 +204,10 @@
 
         <!--  View Area  -->
         <Border
-            BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
-            BorderThickness="1,0,0,0"
             Grid.Column="1"
-            Margin="8,0,0,0">
+            Margin="8,0,0,0"
+            BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
+            BorderThickness="1,0,0,0">
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
@@ -222,43 +222,43 @@
 
                 <!--  Top left corner  -->
                 <Border
-                    Background="{StaticResource LightGrayBrush}"
+                    Grid.Row="0"
                     Grid.Column="0"
-                    Grid.Row="0" />
+                    Background="{StaticResource LightGrayBrush}" />
 
                 <!--  Horizontal ruler  -->
                 <components:Ruler
-                    Background="{StaticResource LightGrayBrush}"
-                    Grid.Column="1"
                     Grid.Row="0"
+                    Grid.Column="1"
                     Height="24"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch"
+                    Background="{StaticResource LightGrayBrush}"
                     HighlightBrush="White"
                     HighlightedRange="{Binding Path=HorizontalRange}"
-                    HorizontalAlignment="Stretch"
                     Orientation="Horizontal"
                     SnapsToDevicePixels="True"
                     Stroke="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
                     UseLayoutRounding="True"
-                    ValueRange="{Binding ElementName=Navigator, Path=HorizontalRange}"
-                    VerticalAlignment="Stretch" />
+                    ValueRange="{Binding ElementName=Navigator, Path=HorizontalRange}" />
 
                 <!--  Vertical ruler  -->
                 <components:Ruler
-                    Background="{StaticResource LightGrayBrush}"
-                    Grid.Column="0"
                     Grid.Row="1"
+                    Grid.Column="0"
+                    Width="24"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch"
+                    Background="{StaticResource LightGrayBrush}"
                     HighlightBrush="White"
                     HighlightedRange="{Binding Path=VerticalRange}"
-                    HorizontalAlignment="Stretch"
                     Invert="True"
                     Orientation="Vertical"
                     RenderTransformOrigin="0.5,0.5"
                     SnapsToDevicePixels="True"
                     Stroke="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
                     UseLayoutRounding="True"
-                    ValueRange="{Binding ElementName=Navigator, Path=VerticalRange}"
-                    VerticalAlignment="Stretch"
-                    Width="24">
+                    ValueRange="{Binding ElementName=Navigator, Path=VerticalRange}">
                     <components:Ruler.RenderTransform>
                         <RotateTransform Angle="180" />
                     </components:Ruler.RenderTransform>
@@ -266,55 +266,71 @@
 
                 <!--  Volume view  -->
                 <components:Navigator
-                    Background="#202020"
-                    Grid.Column="1"
+                    x:Name="Navigator"
                     Grid.Row="1"
+                    Grid.Column="1"
+                    Background="#202020"
                     HorizontalScrollBarVisibility="Auto"
                     IsPanningEnabled="True"
                     IsZoomEnabled="True"
                     Style="{StaticResource OverlayScrollViewer}"
-                    VerticalScrollBarVisibility="Auto"
-                    x:Name="Navigator">
+                    VerticalScrollBarVisibility="Auto">
                     <Grid HorizontalAlignment="Center" VerticalAlignment="Center">
                         <Image
+                            x:Name="Full"
                             Panel.ZIndex="0"
                             RenderOptions.BitmapScalingMode="NearestNeighbor"
                             RenderTransformOrigin="0.5,0.5"
                             Source="{Binding Path=SelectedLayerImage}"
-                            Stretch="None"
-                            x:Name="Full">
+                            Stretch="None">
                             <Image.RenderTransform>
                                 <ScaleTransform ScaleX="1" ScaleY="-1" />
                             </Image.RenderTransform>
                         </Image>
 
                         <Image
+                            Width="{Binding ElementName=Full, Path=ActualWidth}"
                             Height="{Binding ElementName=Full, Path=ActualHeight}"
                             Panel.ZIndex="1"
                             RenderTransformOrigin="0.5,0.5"
                             Source="{Binding Path=PreviewLayerImage}"
                             Stretch="Fill"
-                            Visibility="{Binding ShowPreview, Converter={StaticResource BooleanToVisibilityConverter}}"
-                            Width="{Binding ElementName=Full, Path=ActualWidth}">
+                            Visibility="{Binding ShowPreview, Converter={StaticResource BooleanToVisibilityConverter}}">
                             <Image.RenderTransform>
                                 <ScaleTransform ScaleX="1" ScaleY="-1" />
                             </Image.RenderTransform>
                         </Image>
 
+                        <components:SliceCrosshair
+                            x:Name="Crosshair"
+                            Width="{Binding ElementName=Full, Path=ActualWidth}"
+                            Height="{Binding ElementName=Full, Path=ActualHeight}"
+                            Panel.ZIndex="2"
+                            Background="Transparent"
+                            Foreground="CornflowerBlue"
+                            RenderTransformOrigin="0.5,0.5" />
 
                     </Grid>
                 </components:Navigator>
 
+                <TextBlock
+                    Grid.Row="1"
+                    Grid.Column="1"
+                    Margin="8"
+                    Foreground="CornflowerBlue"
+                    IsHitTestVisible="False"
+                    Text="{Binding ElementName=Crosshair, Path=LastMousePosition}" />
+
                 <!--  Direction selector  -->
                 <Border
-                    Grid.Column="1"
                     Grid.Row="1"
+                    Grid.Column="1"
+                    Width="48"
                     Height="48"
-                    HorizontalAlignment="Left"
                     Margin="24"
-                    Panel.ZIndex="99"
+                    HorizontalAlignment="Left"
                     VerticalAlignment="Bottom"
-                    Width="48">
+                    Panel.ZIndex="99">
 
                     <Canvas>
                         <Canvas.RenderTransform>
@@ -349,50 +365,50 @@
 
                 <!--  Zoom panel  -->
                 <Border
-                    Background="{StaticResource LightGrayBrush}"
-                    CornerRadius="2"
-                    Grid.Column="1"
                     Grid.Row="1"
-                    HorizontalAlignment="Right"
+                    Grid.Column="1"
                     Margin="24"
+                    HorizontalAlignment="Right"
+                    VerticalAlignment="Bottom"
                     Panel.ZIndex="99"
-                    VerticalAlignment="Bottom">
+                    Background="{StaticResource LightGrayBrush}"
+                    CornerRadius="2">
                     <StackPanel Margin="4" Orientation="Horizontal">
                         <TextBlock
                             Margin="4,0"
-                            Text="{Binding ElementName=Navigator, Path=Zoom, StringFormat='Zoom: {0:F2}x'}"
-                            VerticalAlignment="Center" />
+                            VerticalAlignment="Center"
+                            Text="{Binding ElementName=Navigator, Path=Zoom, StringFormat='Zoom: {0:F2}x'}" />
                         <Button
+                            Margin="4,0"
                             Command="{x:Static components:Navigator.ZoomToContentSizeCommand}"
                             CommandParameter="{Binding ElementName=Navigator}"
-                            Margin="4,0"
                             Style="{StaticResource ToolbarButtonStyle}"
                             ToolTip="Fit into view">
-                            <Image Source="/Resources/16px/zoom_fit.png" Style="{StaticResource Icon}" />
+                            <Image Source="pack://application:,,,/PiWeb.Volume.UI;component/Resources/16px/zoom_fit.png" Style="{StaticResource Icon}" />
                         </Button>
                         <Button
                             Command="{x:Static components:Navigator.ResetZoomCommand}"
                             CommandParameter="{Binding ElementName=Navigator}"
                             Style="{StaticResource ToolbarButtonStyle}"
                             ToolTip="Original size">
-                            <Image Source="/Resources/16px/zoom_reset.png" Style="{StaticResource Icon}" />
+                            <Image Source="pack://application:,,,/PiWeb.Volume.UI;component/Resources/16px/zoom_reset.png" Style="{StaticResource Icon}" />
                         </Button>
                     </StackPanel>
                 </Border>
 
                 <Border
-                    BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
-                    BorderThickness="0,1,0,0"
+                    Grid.Row="2"
                     Grid.Column="0"
                     Grid.ColumnSpan="2"
-                    Grid.Row="2" />
+                    BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
+                    BorderThickness="0,1,0,0" />
 
                 <!--  Slice selector  -->
                 <TextBlock
-                    Grid.Column="1"
                     Grid.Row="2"
-                    HorizontalAlignment="Center"
-                    Margin="0,0,0,4">
+                    Grid.Column="1"
+                    Margin="0,0,0,4"
+                    HorizontalAlignment="Center">
                     <TextBlock.Text>
                         <MultiBinding StringFormat="{}Slice: {0}/{1}">
                             <Binding Path="SelectedLayerIndex" />
@@ -401,31 +417,31 @@
                     </TextBlock.Text>
                 </TextBlock>
                 <StackPanel
-                    Grid.Column="1"
                     Grid.Row="3"
-                    HorizontalAlignment="Center"
+                    Grid.Column="1"
                     Margin="0,0,0,8"
+                    HorizontalAlignment="Center"
                     Orientation="Horizontal">
                     <Button
-                        Command="{Binding ShowPreviousSliceCommand}"
                         Margin="4"
+                        Command="{Binding ShowPreviousSliceCommand}"
                         Style="{StaticResource ToolbarButtonStyle}">
-                        <Image Source="/Resources/16px/arrow_left.png" Style="{StaticResource Icon}" />
+                        <Image Source="pack://application:,,,/PiWeb.Volume.UI;component/Resources/16px/arrow_left.png" Style="{StaticResource Icon}" />
                     </Button>
                     <Slider
+                        Width="240"
+                        VerticalAlignment="Center"
                         LargeChange="10"
                         Maximum="{Binding MaxLayer}"
                         Minimum="0"
                         Orientation="Horizontal"
                         SmallChange="1"
-                        Value="{Binding SelectedLayerIndex}"
-                        VerticalAlignment="Center"
-                        Width="240" />
+                        Value="{Binding SelectedLayerIndex}" />
                     <Button
-                        Command="{Binding ShowNextSliceCommand}"
                         Margin="4"
+                        Command="{Binding ShowNextSliceCommand}"
                         Style="{StaticResource ToolbarButtonStyle}">
-                        <Image Source="/Resources/16px/arrow_right.png" Style="{StaticResource Icon}" />
+                        <Image Source="pack://application:,,,/PiWeb.Volume.UI;component/Resources/16px/arrow_right.png" Style="{StaticResource Icon}" />
                     </Button>
                 </StackPanel>
             </Grid>

--- a/src/PiWeb.Volume.UI/ViewModel/CodecViewModel.cs
+++ b/src/PiWeb.Volume.UI/ViewModel/CodecViewModel.cs
@@ -14,6 +14,7 @@ namespace Zeiss.PiWeb.Volume.UI.ViewModel
 
 	using System;
 	using System.Collections.Generic;
+	using System.Globalization;
 	using GalaSoft.MvvmLight;
 	using GalaSoft.MvvmLight.Messaging;
 
@@ -23,7 +24,9 @@ namespace Zeiss.PiWeb.Volume.UI.ViewModel
 	{
 		#region members
 
-		private int _Quality = 75;
+		private static int _Quality = 75;
+		private static double _QuantizationBase = 12;
+		private static double _QuantizationGain = 1;
 
 		#endregion
 
@@ -37,6 +40,18 @@ namespace Zeiss.PiWeb.Volume.UI.ViewModel
 			set => Set( ref _Quality, value );
 		}
 
+		public double QuantizationBase
+		{
+			get => _QuantizationBase;
+			set => Set( ref _QuantizationBase, value );
+		}
+
+		public double QuantizationGain
+		{
+			get => _QuantizationGain;
+			set => Set( ref _QuantizationGain, value );
+		}
+
 		#endregion
 
 		#region methods
@@ -45,7 +60,9 @@ namespace Zeiss.PiWeb.Volume.UI.ViewModel
 		{
 			return new VolumeCompressionOptions( "zeiss.block", "gray8", new Dictionary<string, string>
 			{
-				{ "quality", Math.Max( 5, Math.Min( 100, Quality ) ).ToString() }
+				{ "quality", Math.Max( 5, Math.Min( 100, Quality ) ).ToString(CultureInfo.InvariantCulture) },
+				{ "quantizationBase", Math.Max( 4, Math.Min( 24, QuantizationBase ) ).ToString(CultureInfo.InvariantCulture) },
+				{ "quantizationGain", Math.Max( 0.25, Math.Min( 4, QuantizationGain ) ).ToString(CultureInfo.InvariantCulture) }
 			}, 0 );
 		}
 

--- a/src/PiWeb.Volume/Block/BlockVolumeDecoder.cs
+++ b/src/PiWeb.Volume/Block/BlockVolumeDecoder.cs
@@ -160,10 +160,18 @@ namespace Zeiss.PiWeb.Volume.Block
 		private static void ReadBlock( ReadOnlySpan<byte> data, EncodedBlockInfo encodedBlockInfo, Span<double> result )
 		{
 			var encodedBlockData = data.Slice( encodedBlockInfo.StartIndex, encodedBlockInfo.Length );
+			for( var i = 1; i < BlockVolume.N3; i++ )
+				result[ i ] = 0;
+
+			if( encodedBlockInfo.Length == 0 )
+				return;
 
 			result[ 0 ] = encodedBlockInfo.FirstValueSize == 1
 				? MemoryMarshal.Read<sbyte>( encodedBlockData )
 				: MemoryMarshal.Read<short>( encodedBlockData );
+
+			if( encodedBlockInfo.Length == encodedBlockInfo.FirstValueSize )
+				return;
 
 			var otherValueData = encodedBlockData
 				.Slice( encodedBlockInfo.FirstValueSize, encodedBlockInfo.Length - encodedBlockInfo.FirstValueSize );
@@ -171,14 +179,14 @@ namespace Zeiss.PiWeb.Volume.Block
 			if( encodedBlockInfo.OtherValuesSize == 1 )
 			{
 				var values = MemoryMarshal.Cast<byte, sbyte>( otherValueData );
-				for( ushort i = 1, vi = 0; i < BlockVolume.N3; i++, vi++ )
-					result[ i ] = i >= encodedBlockInfo.ValueCount ? 0 : values[ vi ];
+				for( ushort i = 1, vi = 0; i < encodedBlockInfo.ValueCount; i++, vi++ )
+					result[ i ] = values[ vi ];
 			}
 			else
 			{
 				var values = MemoryMarshal.Cast<byte, short>( otherValueData );
-				for( ushort i = 1, vi = 0; i < BlockVolume.N3; i++, vi++ )
-					result[ i ] = i >= encodedBlockInfo.ValueCount ? 0 : values[ vi ];
+				for( ushort i = 1, vi = 0; i < encodedBlockInfo.ValueCount; i++, vi++ )
+					result[ i ] = values[ vi ];
 			}
 		}
 

--- a/src/PiWeb.Volume/Block/BlockVolumeDecoder.cs
+++ b/src/PiWeb.Volume/Block/BlockVolumeDecoder.cs
@@ -16,6 +16,7 @@ namespace Zeiss.PiWeb.Volume.Block
 	using System;
 	using System.Buffers;
 	using System.IO;
+	using System.Runtime.InteropServices;
 	using System.Threading;
 	using System.Threading.Tasks;
 
@@ -25,7 +26,7 @@ namespace Zeiss.PiWeb.Volume.Block
 	{
 		#region methods
 
-		internal void Decode( Stream input,
+		internal static void Decode( byte[] data,
 			VolumeMetadata metadata,
 			BlockAction blockAction,
 			LayerPredicate? layerPredicate = null,
@@ -36,25 +37,22 @@ namespace Zeiss.PiWeb.Volume.Block
 			var zigzag = ZigZag.Calculate();
 			var (bcx, bcy, bcz) = BlockVolume.GetBlockCount( metadata );
 			var blockCount = bcx * bcy;
-			var encodedBlockLengths = new ushort[ blockCount ];
-			var encodedBlocks = new short[ blockCount * BlockVolume.N3 ];
-
-			using var reader = new BinaryReader( input );
+			var encodedBlockInfos = new EncodedBlockInfo[ blockCount ];
+			var reader = new BinaryReader( new MemoryStream( data ) );
 
 			ReadMetadata( reader, out var quantization );
 
 			for( ushort biz = 0; biz < bcz; biz++ )
 			{
 				ct.ThrowIfCancellationRequested();
+
+				ReadLayerInfos( reader, blockCount, encodedBlockInfos );
+
 				if( layerPredicate?.Invoke( biz ) is false )
-				{
-					SkipLayer( reader, blockCount );
-				}
-				else
-				{
-					ReadLayer( reader, blockCount, encodedBlocks, encodedBlockLengths );
-					DecodeLayer( encodedBlocks, encodedBlockLengths, bcx, bcy, biz, quantization, zigzag, blockPredicate, blockAction );
-				}
+					continue;
+
+				DecodeLayer( data, encodedBlockInfos, bcx, bcy, biz, quantization, zigzag, blockPredicate, blockAction );
+
 
 				progress?.Report( new VolumeSliceDefinition( Direction.Z, (ushort)( biz * BlockVolume.N ) ) );
 			}
@@ -73,55 +71,36 @@ namespace Zeiss.PiWeb.Volume.Block
 			quantization = Quantization.Read( reader, true );
 		}
 
-		private static void SkipLayer( BinaryReader reader, int blockCount )
+		private static void ReadLayerInfos( BinaryReader reader, int blockCount, EncodedBlockInfo[] encodedBlockInfos )
 		{
 			for( var i = 0; i < blockCount; i++ )
 			{
-				var resultLength = reader.ReadUInt16();
-
-				var length = resultLength & 0x0FFF;
-				var firstLength = ( resultLength & 0b0011000000000000 ) >> 12;
-				var otherLength = ( resultLength & 0b1100000000000000 ) >> 14;
-
-				var count = 0;
-				if( length > 0 )
-					count += firstLength;
-				if( length > 1 )
-					count += ( length - 1 ) * otherLength;
-
-				reader.BaseStream.Seek( count, SeekOrigin.Current );
+				var encodedBlockInfo = EncodedBlockInfo.Read( reader );
+				reader.BaseStream.Seek( encodedBlockInfo.Length, SeekOrigin.Current );
+				encodedBlockInfos[ i ] = encodedBlockInfo;
 			}
 		}
 
-		private static void ReadLayer( BinaryReader reader, int blockCount, short[] encodedBlocks, ushort[] encodedBlockLengths )
+		private readonly record struct EncodedBlockInfo( int StartIndex, ushort ValueCount, byte FirstValueSize, byte OtherValuesSize )
 		{
-			var blockBuffer = ArrayPool<short>.Shared.Rent( BlockVolume.N3 );
+			public ushort Length => (ushort)( FirstValueSize + ( ValueCount - 1 ) * OtherValuesSize );
 
-			for( var i = 0; i < blockCount; i++ )
+			public static EncodedBlockInfo Read( BinaryReader reader )
 			{
 				var resultLength = reader.ReadUInt16();
 
-				var dataIndex = 0;
-				var length = resultLength & 0x0FFF;
-				var firstLength = ( resultLength & 0b0011000000000000 ) >> 12;
-				var otherLength = ( resultLength & 0b1100000000000000 ) >> 14;
+				var startIndex = (int)reader.BaseStream.Position;
+				var valueCount = resultLength & 0x0FFF;
+				var firstValueSize = ( resultLength & 0b0011000000000000 ) >> 12;
+				var otherValuesSize = ( resultLength & 0b1100000000000000 ) >> 14;
 
-				encodedBlockLengths[ i ] = (ushort)length;
-				if( length > 0 )
-					blockBuffer[ dataIndex++ ] = firstLength == 2 ? reader.ReadInt16() : reader.ReadSByte();
-
-				for( var j = 1; j < length; j++ )
-					blockBuffer[ dataIndex++ ] = otherLength == 2 ? reader.ReadInt16() : reader.ReadSByte();
-
-				Buffer.BlockCopy( blockBuffer, 0, encodedBlocks, i * BlockVolume.N3 * sizeof( short ), BlockVolume.N3 * sizeof( short ) );
+				return new EncodedBlockInfo( startIndex, (ushort)valueCount, (byte)firstValueSize, (byte)otherValuesSize );
 			}
-
-			ArrayPool<short>.Shared.Return( blockBuffer );
 		}
 
 		private static void DecodeLayer(
-			short[] encodedBlocks,
-			ushort[] encodedBlockLengths,
+			byte[] encodedBlocks,
+			EncodedBlockInfo[] encodedBlockInfos,
 			ushort blockCountX,
 			ushort blockCountY,
 			ushort blockIndexZ,
@@ -143,15 +122,13 @@ namespace Zeiss.PiWeb.Volume.Block
 					if( blockPredicate?.Invoke( blockIndex ) == false )
 						return buffers;
 
-					var encodedLength = encodedBlockLengths[ index ];
-
-					var doubleBuffer1 = buffers.Item1;
-					var doubleBuffer2 = buffers.Item2;
+					var doubleBuffer1 = buffers.Item1.AsSpan();
+					var doubleBuffer2 = buffers.Item2.AsSpan();
 					var byteBuffer = buffers.Item3;
+					var encodedBlockInfo = encodedBlockInfos[ index ];
 
 					//1. Dediscretization
-					for( int i = 0, di = index * BlockVolume.N3; i < BlockVolume.N3; i++, di++ )
-						doubleBuffer1[ i ] = i >= encodedLength ? 0 : encodedBlocks[ di ];
+					ReadBlock( encodedBlocks.AsSpan(), encodedBlockInfo, doubleBuffer1 );
 
 					//2. ZigZag
 					for( var i = 0; i < BlockVolume.N3; i++ )
@@ -166,7 +143,7 @@ namespace Zeiss.PiWeb.Volume.Block
 
 					//5. Discretization
 					for( var i = 0; i < BlockVolume.N3; i++ )
-						byteBuffer[ i ] = (byte)Math.Max( byte.MinValue, Math.Min( byte.MaxValue, Math.Round( doubleBuffer1[ i ] ) ) );
+						byteBuffer[ i ] = (byte)Math.Clamp( Math.Round( doubleBuffer1[ i ] ), byte.MinValue, byte.MaxValue );
 
 					blockAction( byteBuffer, blockIndex );
 
@@ -178,6 +155,31 @@ namespace Zeiss.PiWeb.Volume.Block
 					ArrayPool<double>.Shared.Return( buffers.Item2 );
 					ArrayPool<byte>.Shared.Return( buffers.Item3 );
 				} );
+		}
+
+		private static void ReadBlock( ReadOnlySpan<byte> data, EncodedBlockInfo encodedBlockInfo, Span<double> result )
+		{
+			var encodedBlockData = data.Slice( encodedBlockInfo.StartIndex, encodedBlockInfo.Length );
+
+			result[ 0 ] = encodedBlockInfo.FirstValueSize == 1
+				? MemoryMarshal.Read<sbyte>( encodedBlockData )
+				: MemoryMarshal.Read<short>( encodedBlockData );
+
+			var otherValueData = encodedBlockData
+				.Slice( encodedBlockInfo.FirstValueSize, encodedBlockInfo.Length - encodedBlockInfo.FirstValueSize );
+
+			if( encodedBlockInfo.OtherValuesSize == 1 )
+			{
+				var values = MemoryMarshal.Cast<byte, sbyte>( otherValueData );
+				for( ushort i = 1, vi = 0; i < BlockVolume.N3; i++, vi++ )
+					result[ i ] = i >= encodedBlockInfo.ValueCount ? 0 : values[ vi ];
+			}
+			else
+			{
+				var values = MemoryMarshal.Cast<byte, short>( otherValueData );
+				for( ushort i = 1, vi = 0; i < BlockVolume.N3; i++, vi++ )
+					result[ i ] = i >= encodedBlockInfo.ValueCount ? 0 : values[ vi ];
+			}
 		}
 
 		#endregion

--- a/src/PiWeb.Volume/Block/BlockVolumeDecompressor.cs
+++ b/src/PiWeb.Volume/Block/BlockVolumeDecompressor.cs
@@ -56,11 +56,9 @@ namespace Zeiss.PiWeb.Volume.Block
 			if( _Volume.CompressedData[ Direction.Z ] is not {} data )
 				throw new NotSupportedException( Resources.GetResource<Volume>( "CompressedDataMissing_ErrorText" ) );
 
-			var decoder = new BlockVolumeDecoder();
-			var input = new MemoryStream( data );
 			var result = VolumeSliceHelper.CreateSliceBuffer( _SizeX, _SizeY, _SizeZ );
 
-			decoder.Decode( input, _Metadata, ( block, index ) =>
+			BlockVolumeDecoder.Decode( data, _Metadata, ( block, index ) =>
 			{
 				for( var bz = 0; bz < BlockVolume.N; bz++ )
 				for( var by = 0; by < BlockVolume.N; by++ )

--- a/src/PiWeb.Volume/Block/BlockVolumePreviewCreator.cs
+++ b/src/PiWeb.Volume/Block/BlockVolumePreviewCreator.cs
@@ -64,12 +64,9 @@ namespace Zeiss.PiWeb.Volume.Block
 			if( _Volume.CompressedData[ Direction.Z ] is not {} data )
 				throw new NotSupportedException( Resources.GetResource<Volume>( "CompressedDataMissing_ErrorText" ) );
 
-			var decoder = new BlockVolumeDecoder();
-			var input = new MemoryStream( data );
-
 			var result = VolumeSliceHelper.CreateSliceBuffer( _PreviewSizeX, _PreviewSizeY, _PreviewSizeZ );
 
-			decoder.Decode( input, _Metadata, ( block, index ) =>
+			BlockVolumeDecoder.Decode( data, _Metadata, ( block, index ) =>
 			{
 				for( var bz = 0; bz < BlockVolume.N; bz++ )
 				for( var by = 0; by < BlockVolume.N; by++ )

--- a/src/PiWeb.Volume/Block/BlockVolumeSliceRangeCollector.cs
+++ b/src/PiWeb.Volume/Block/BlockVolumeSliceRangeCollector.cs
@@ -119,10 +119,7 @@ namespace Zeiss.PiWeb.Volume.Block
 			if( _Volume.CompressedData[ Direction.Z ] is not { } data )
 				throw new NotSupportedException( Resources.GetResource<Volume>( "CompressedDataMissing_ErrorText" ) );
 
-			var decoder = new BlockVolumeDecoder();
-			var input = new MemoryStream( data );
-
-			decoder.Decode( input, _Metadata, BlockAction, LayerPredicate, BlockPredicate, progress, ct );
+			BlockVolumeDecoder.Decode( data, _Metadata, BlockAction, LayerPredicate, BlockPredicate, progress, ct );
 
 			return new VolumeSliceCollection(
 				_SlicesX.Values

--- a/src/PiWeb.Volume/Block/DiscreteCosineTransform.cs
+++ b/src/PiWeb.Volume/Block/DiscreteCosineTransform.cs
@@ -50,9 +50,9 @@ namespace Zeiss.PiWeb.Volume.Block
 			return result;
 		}
 
-		internal static void Transform( double[] values, double[] result, bool inverse = false )
+		internal static void Transform( Span<double> values, Span<double> result, bool inverse = false )
 		{
-			var pU = inverse ? Ut : U;
+			var pU = inverse ? Ut.AsSpan() : U.AsSpan();
 			int u, p, x, y, z;
 
 			Vector512<double> vecv;
@@ -61,12 +61,12 @@ namespace Zeiss.PiWeb.Volume.Block
 			for( z = 0, p = 0; z < BlockVolume.N; z++ )
 			for( y = 0; y < BlockVolume.N; y++, p += BlockVolume.N )
 			{
-				vecv = Vector512.Create( values, p );
+				vecv = Vector512.Create<double>( values.Slice( p, BlockVolume.N ) );
 				for( x = 0, u = 0; x < BlockVolume.N; x++, u += BlockVolume.N )
 				{
 					//u = x * N;
 					//p = z * NN + y * N;
-					result[ z * BlockVolume.N2 + x * BlockVolume.N + y ] = Vector512.Sum( Vector512.Multiply( vecv, Vector512.Create( pU, u ) ) );
+					result[ z * BlockVolume.N2 + x * BlockVolume.N + y ] = Vector512.Sum( Vector512.Multiply( vecv, Vector512.Create<double>( pU.Slice( u, BlockVolume.N ) ) ) );
 				}
 			}
 
@@ -74,12 +74,12 @@ namespace Zeiss.PiWeb.Volume.Block
 			for( z = 0, p = 0; z < BlockVolume.N; z++ )
 			for( x = 0; x < BlockVolume.N; x++, p += BlockVolume.N )
 			{
-				vecv = Vector512.Create( result, p );
+				vecv = Vector512.Create<double>( result.Slice( p, BlockVolume.N ) );
 				for( y = 0, u = 0; y < BlockVolume.N; y++, u += BlockVolume.N )
 				{
 					//u = y * N;
 					//p = z * NN + x * N;
-					values[ y * BlockVolume.N2 + x * BlockVolume.N + z ] = Vector512.Sum( Vector512.Multiply( vecv, Vector512.Create( pU, u ) ) );
+					values[ y * BlockVolume.N2 + x * BlockVolume.N + z ] = Vector512.Sum( Vector512.Multiply( vecv, Vector512.Create<double>( pU.Slice( u, BlockVolume.N ) ) ) );
 				}
 			}
 
@@ -87,12 +87,12 @@ namespace Zeiss.PiWeb.Volume.Block
 			for( y = 0, p = 0; y < BlockVolume.N; y++ )
 			for( x = 0; x < BlockVolume.N; x++, p += BlockVolume.N )
 			{
-				vecv = Vector512.Create( values, p );
+				vecv = Vector512.Create<double>( values.Slice( p, BlockVolume.N ) );
 				for( z = 0, u = 0; z < BlockVolume.N; z++, u += BlockVolume.N )
 				{
 					//u = z * N;
 					//p = y * NN + x * N;
-					result[ z * BlockVolume.N2 + y * BlockVolume.N + x ] = Vector512.Sum( Vector512.Multiply( vecv, Vector512.Create( pU, u ) ) );
+					result[ z * BlockVolume.N2 + y * BlockVolume.N + x ] = Vector512.Sum( Vector512.Multiply( vecv, Vector512.Create<double>( pU.Slice( u, BlockVolume.N ) ) ) );
 				}
 			}
 		}

--- a/src/PiWeb.Volume/CompressedVolume.cs
+++ b/src/PiWeb.Volume/CompressedVolume.cs
@@ -300,7 +300,7 @@ namespace Zeiss.PiWeb.Volume
 			var sw = Stopwatch.StartNew();
 			try
 			{
-				using var zipOutput = new ZipArchive( stream, ZipArchiveMode.Create );
+				using var zipOutput = new ZipArchive( stream, ZipArchiveMode.Create, true );
 
 				var metaDataEntry = zipOutput.CreateNormalizedEntry( "Metadata.xml", CompressionLevel.Optimal );
 				using( var metaDataEntryStream = metaDataEntry.Open() )

--- a/src/PiWeb.Volume/VolumeRange.cs
+++ b/src/PiWeb.Volume/VolumeRange.cs
@@ -17,6 +17,15 @@ namespace Zeiss.PiWeb.Volume;
 /// <param name="End">Inclusive end</param>
 public readonly record struct VolumeRange( ushort Start, ushort End )
 {
+	#region properties
+
+	/// <summary>
+	/// The size of the range.
+	/// </summary>
+	public ushort Size => (ushort)( End - Start + 1 );
+
+	#endregion
+
 	#region methods
 
 	/// <summary>


### PR DESCRIPTION
This PR changes the way the block volume is decoded. Previously, we used a binary reader to read the block data from the byte array up front. Now, we only read the block information and work directly on the original data stream, using spans and memory marshalling.

Also, I've introduced a few new ways to customize the quantization matrix.