### PR TITLE
fix: encoder quantization was applied multiple times

### DIFF
--- a/src/PiWeb.Volume.UI/ViewModel/CodecViewModel.cs
+++ b/src/PiWeb.Volume.UI/ViewModel/CodecViewModel.cs
@@ -17,6 +17,7 @@ namespace Zeiss.PiWeb.Volume.UI.ViewModel
 	using System.Globalization;
 	using GalaSoft.MvvmLight;
 	using GalaSoft.MvvmLight.Messaging;
+	using Zeiss.PiWeb.Volume.Block;
 
 	#endregion
 
@@ -58,11 +59,11 @@ namespace Zeiss.PiWeb.Volume.UI.ViewModel
 
 		public VolumeCompressionOptions GetOptions()
 		{
-			return new VolumeCompressionOptions( "zeiss.block", "gray8", new Dictionary<string, string>
+			return new VolumeCompressionOptions( BlockVolume.EncoderID, BlockVolume.PixelFormat, new Dictionary<string, string>
 			{
-				{ "quality", Math.Max( 5, Math.Min( 100, Quality ) ).ToString(CultureInfo.InvariantCulture) },
-				{ "quantizationBase", Math.Max( 4, Math.Min( 24, QuantizationBase ) ).ToString(CultureInfo.InvariantCulture) },
-				{ "quantizationGain", Math.Max( 0.25, Math.Min( 4, QuantizationGain ) ).ToString(CultureInfo.InvariantCulture) }
+				{ BlockVolume.QualityName, Math.Max( 5, Math.Min( 100, Quality ) ).ToString( CultureInfo.InvariantCulture ) },
+				{ BlockVolume.QuantizationBaseName, Math.Max( 4, Math.Min( 24, QuantizationBase ) ).ToString( CultureInfo.InvariantCulture ) },
+				{ BlockVolume.QuantizationGainName, Math.Max( 0.25, Math.Min( 4, QuantizationGain ) ).ToString( CultureInfo.InvariantCulture ) }
 			}, 0 );
 		}
 

--- a/src/PiWeb.Volume/Block/BlockVolume.cs
+++ b/src/PiWeb.Volume/Block/BlockVolume.cs
@@ -23,7 +23,7 @@ using System.Threading;
 /// <summary>
 /// A Volume that is not compressed in slices, but in blocks. This is optimal for performance/memory tradeoff.
 /// </summary>
-internal class BlockVolume : CompressedVolume
+public class BlockVolume : CompressedVolume
 {
 	#region constants
 
@@ -38,12 +38,32 @@ internal class BlockVolume : CompressedVolume
 	/// <summary>
 	/// The id of the block volume encoder.
 	/// </summary>
-	internal const string EncoderID = "zeiss.block";
+	public const string EncoderID = "zeiss.block";
 
 	/// <summary>
 	///  The pixel format of the block volume encoder.
 	/// </summary>
-	internal const string PixelFormat = "gray8";
+	public const string PixelFormat = "gray8";
+
+	/// <summary>
+	/// Name of the quality option.
+	/// </summary>
+	public const string QualityName = "quality";
+
+	/// <summary>
+	/// Name of the quantization option.
+	/// </summary>
+	public const string QuantizationName = "quantization";
+
+	/// <summary>
+	/// Name of the quantization base option.
+	/// </summary>
+	public const string QuantizationBaseName = "quantizationBase";
+
+	/// <summary>
+	/// Name of the quantization gain option.
+	/// </summary>
+	public const string QuantizationGainName = "quantizationGain";
 
 	/// <summary>
 	/// File header to identify block volumes. Reads as JSVF.

--- a/src/PiWeb.Volume/Block/Quantization.cs
+++ b/src/PiWeb.Volume/Block/Quantization.cs
@@ -62,11 +62,11 @@ internal static class Quantization
 	{
 		if( options.EncoderOptions.TryGetQuantization( out var result ) )
 			return result;
-		if( !options.EncoderOptions.TryGetDouble( "quality", out var quality ) )
+		if( !options.EncoderOptions.TryGetDouble( BlockVolume.QualityName, out var quality ) )
 			quality = 75;
-		if( !options.EncoderOptions.TryGetDouble( "quantizationBase", out var quantizationBase ) )
+		if( !options.EncoderOptions.TryGetDouble( BlockVolume.QuantizationBaseName, out var quantizationBase ) )
 			quantizationBase = 12;
-		if( !options.EncoderOptions.TryGetDouble( "quantizationGain", out var quantizationGain ) )
+		if( !options.EncoderOptions.TryGetDouble( BlockVolume.QuantizationGainName, out var quantizationGain ) )
 			quantizationGain = 1;
 
 		return Calculate( quality, quantizationBase, quantizationGain );
@@ -75,7 +75,7 @@ internal static class Quantization
 	private static bool TryGetQuantization( this IReadOnlyDictionary<string, string> options, [NotNullWhen( true )] out double[]? result )
 	{
 		result = default;
-		if( !options.TryGetValue( "quantization", out var quantizationString ) )
+		if( !options.TryGetValue( BlockVolume.QuantizationName, out var quantizationString ) )
 			return false;
 
 		var parts = quantizationString.Split( ';' );


### PR DESCRIPTION
The resulting volumes were incredibly small, but unfortunately, empty.