### PR TITLE
fix: add region of interest for single slice extraction

### DIFF
--- a/src/PiWeb.Volume/Block/BlockVolumeSliceRangeCollector.cs
+++ b/src/PiWeb.Volume/Block/BlockVolumeSliceRangeCollector.cs
@@ -57,6 +57,9 @@ internal class BlockVolumeSliceRangeCollector
 
 		map[ block ] = [new BlockSliceBuffer( definition, sliceBuffer )];
 
+		if( definition.Direction != Direction.Z && definition.RegionOfInterest.HasValue )
+			_VerticalRanges.Add( definition.RegionOfInterest.Value.V );
+
 		if( _VerticalRanges.Count == 0 && ( _SlicesX.Count > 0 || _SlicesY.Count > 0 ) )
 			_VerticalRanges.Add( new VolumeRange( 0, (ushort)( _Metadata.SizeZ - 1 ) ) );
 	}


### PR DESCRIPTION
When extracting a single slice, the region of interest for vertical slices was not added to the region list, so the full height was decompressed instead of only the required part.