### PR TITLE
Feature/jan/decoding performance

### DIFF
--- a/src/PiWeb.Volume/Block/BlockInfo.cs
+++ b/src/PiWeb.Volume/Block/BlockInfo.cs
@@ -55,14 +55,13 @@ internal readonly record struct BlockInfo( ushort ValueCount, bool IsFirstValueS
 	#region methods
 
 	/// <summary>
-	/// Reads the <see cref="BlockInfo"/> from the specified <paramref name="reader"/>.
+	/// Reads the <see cref="BlockInfo"/> from the specified <paramref name="value"/>.
 	/// </summary>
-	public static BlockInfo Read( BinaryReader reader )
+	public static BlockInfo Create( ushort value )
 	{
-		var resultLength = reader.ReadUInt16();
-		var valueCount = resultLength & ValueCountMask;
-		var isFirstValueShort = ( resultLength & IsFirstValueShortMask ) >> IsFirstValueShortOffset;
-		var areOtherValuesShort = ( resultLength & AreOtherValuesShortMask ) >> AreOtherValuesShortOffset;
+		var valueCount = value & ValueCountMask;
+		var isFirstValueShort = ( value & IsFirstValueShortMask ) >> IsFirstValueShortOffset;
+		var areOtherValuesShort = ( value & AreOtherValuesShortMask ) >> AreOtherValuesShortOffset;
 
 		return new BlockInfo( (ushort)valueCount, isFirstValueShort > 0, areOtherValuesShort > 0 );
 	}

--- a/src/PiWeb.Volume/Block/BlockVolume.cs
+++ b/src/PiWeb.Volume/Block/BlockVolume.cs
@@ -190,8 +190,8 @@ public class BlockVolume : CompressedVolume
 		CancellationToken ct = default )
 	{
 		var sw = Stopwatch.StartNew();
-		var sliceRangeCollector = new BlockVolumeSliceRangeCollector( this, slice, buffer );
-		sliceRangeCollector.CollectSliceRanges( progress, ct );
+		var sliceCollector = new BlockVolumeSliceCollector( this, slice, buffer );
+		sliceCollector.CollectSlice( progress, ct );
 
 		logger?.Log( LogLevel.Info, $"Extracted '{slice}' in {sw.ElapsedMilliseconds} ms." );
 	}

--- a/src/PiWeb.Volume/Block/BlockVolumeDecompressor.cs
+++ b/src/PiWeb.Volume/Block/BlockVolumeDecompressor.cs
@@ -79,12 +79,13 @@ internal class BlockVolumeDecompressor
 		for( var bz = 0; bz < sz; bz++ )
 		{
 			var gz = index.Z * BlockVolume.N + bz;
+			var oz = bz * BlockVolume.N2;
 			var sliceData = _Result[ gz ].AsSpan();
 
 			for( var by = 0; by < sy; by++ )
 			{
 				var gy = index.Y * BlockVolume.N + by;
-				block.Slice( bz * BlockVolume.N2 + by * BlockVolume.N, sx ).CopyTo( sliceData.Slice( gy * _SizeX + gx, sx ) );
+				block.Slice( oz + by * BlockVolume.N, sx ).CopyTo( sliceData.Slice( gy * _SizeX + gx, sx ) );
 			}
 		}
 	}

--- a/src/PiWeb.Volume/Block/BlockVolumeEncoder.cs
+++ b/src/PiWeb.Volume/Block/BlockVolumeEncoder.cs
@@ -211,7 +211,7 @@ internal static class BlockVolumeEncoder
 
 			//4. Discretization
 			for( var i = 0; i < BlockVolume.N3; i++ )
-				resultBlock[ i ] = (short)Math.Clamp( Math.Round( inputBlock[ i ] ), short.MinValue, short.MaxValue );
+				resultBlock[ i ] = (short)Math.Clamp( inputBlock[ i ], short.MinValue, short.MaxValue );
 
 			blockInfos[ blockIndex ] = BlockInfo.Create( resultBlock );
 

--- a/src/PiWeb.Volume/Block/BlockVolumeEncoder.cs
+++ b/src/PiWeb.Volume/Block/BlockVolumeEncoder.cs
@@ -211,7 +211,7 @@ internal static class BlockVolumeEncoder
 
 			//4. Discretization
 			for( var i = 0; i < BlockVolume.N3; i++ )
-				resultBlock[ i ] = (short)Math.Clamp( inputBlock[ i ], short.MinValue, short.MaxValue );
+				resultBlock[ i ] = (short)Math.Clamp( Math.Round( inputBlock[ i ] ), short.MinValue, short.MaxValue );
 
 			blockInfos[ blockIndex ] = BlockInfo.Create( resultBlock );
 

--- a/src/PiWeb.Volume/Block/BlockVolumeMetaData.cs
+++ b/src/PiWeb.Volume/Block/BlockVolumeMetaData.cs
@@ -14,13 +14,14 @@ namespace Zeiss.PiWeb.Volume.Block;
 
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 
 #endregion
 
 /// <summary>
 /// Holds information that are needed to encode and decode a block volume.
 /// </summary>
-public readonly record struct BlockVolumeMetaData( uint Version, ushort SizeX, ushort SizeY, ushort SizeZ, double[] Quantization )
+public record BlockVolumeMetaData( uint Version, ushort SizeX, ushort SizeY, ushort SizeZ, double[] Quantization )
 {
 	#region methods
 
@@ -40,26 +41,37 @@ public readonly record struct BlockVolumeMetaData( uint Version, ushort SizeX, u
 	}
 
 	/// <summary>
-	/// Reads the metadata from the specified <paramref name="reader"/>
+	/// Reads the metadata from the specified <paramref name="data"/>
 	/// </summary>
-	public static BlockVolumeMetaData Read( BinaryReader reader )
+	public static BlockVolumeMetaData Create( ReadOnlySpan<byte> data )
 	{
-		var header = reader.ReadUInt32();
+		var position = 0;
+		var header = MemoryMarshal.Read<uint>( data[ position.. ] );
+		position += sizeof( uint );
 		if( header != BlockVolume.FileHeader )
 			throw new FormatException( $"Encountered unexpected file header 0x{header:x8}, expected 0x{BlockVolume.FileHeader:x8}" );
 
-		var version = reader.ReadUInt32();
+		var version = MemoryMarshal.Read<uint>( data[ position.. ] );
+		position += sizeof( uint );
 		if( version != BlockVolume.Version )
 			throw new FormatException( $"Encountered unexpected file header '{version}', expected {BlockVolume.Version}" );
 
-		var sizeX = reader.ReadUInt16();
-		var sizeY = reader.ReadUInt16();
-		var sizeZ = reader.ReadUInt16();
+		var sizeX = MemoryMarshal.Read<ushort>( data[ position.. ] );
+		position += sizeof( ushort );
+		var sizeY = MemoryMarshal.Read<ushort>( data[ position.. ] );
+		position += sizeof( ushort );
+		var sizeZ = MemoryMarshal.Read<ushort>( data[ position.. ] );
+		position += sizeof( ushort );
 
-		var quantization = Block.Quantization.Read( reader, true );
+		var quantization = MemoryMarshal.Cast<byte, double>( data.Slice( position, BlockVolume.N3 * sizeof( double ) ) );
 
-		return new BlockVolumeMetaData( version, sizeX, sizeY, sizeZ, quantization );
+		return new BlockVolumeMetaData( version, sizeX, sizeY, sizeZ, quantization.ToArray() );
 	}
 
 	#endregion
+
+	/// <summary>
+	/// The number of bytes the header consists of.
+	/// </summary>
+	public static int HeaderLength => 2 * sizeof( uint ) + 3 * sizeof( ushort ) + BlockVolume.N3 * sizeof( double );
 }

--- a/src/PiWeb.Volume/Block/BlockVolumeSliceCollector.cs
+++ b/src/PiWeb.Volume/Block/BlockVolumeSliceCollector.cs
@@ -1,0 +1,222 @@
+#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2020                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Volume.Block;
+
+#region usings
+
+using System;
+using System.Threading;
+
+#endregion
+
+/// <summary>
+/// Can be used to search through a block volume and extract single slices and slice ranges.
+/// </summary>
+internal class BlockVolumeSliceCollector
+{
+	#region members
+
+	private readonly BlockVolume _Volume;
+
+	private readonly ushort _SizeZ;
+	private readonly ushort _SizeY;
+	private readonly ushort _SizeX;
+	private readonly byte[] _SliceBuffer;
+	private readonly VolumeRange _RangeX;
+	private readonly VolumeRange _RangeY;
+	private readonly VolumeRange _RangeZ;
+	private readonly ushort _Index;
+	private readonly BlockVolumeDecoder.BlockAction _BlockAction;
+
+	#endregion
+
+	#region constructors
+
+	internal BlockVolumeSliceCollector( BlockVolume volume, VolumeSliceDefinition definition, byte[] sliceBuffer )
+	{
+		_Volume = volume;
+		_Index = definition.Index;
+		_SliceBuffer = sliceBuffer;
+
+		_SizeZ = volume.Metadata.SizeZ;
+		_SizeY = volume.Metadata.SizeY;
+		_SizeX = volume.Metadata.SizeX;
+
+		var (bsx, bsy, bsz) = BlockVolume.GetBlockCount( _SizeX, _SizeY, _SizeZ );
+		var blockIndex = (ushort)( definition.Index / BlockVolume.N );
+
+		_RangeX = new VolumeRange( 0, (ushort)( bsx - 1 ) );
+		_RangeY = new VolumeRange( 0, (ushort)( bsy - 1 ) );
+		_RangeZ = new VolumeRange( 0, (ushort)( bsz - 1 ) );
+
+		switch( definition.Direction )
+		{
+			case Direction.Z:
+			{
+				_RangeZ = new VolumeRange( blockIndex, blockIndex );
+				_BlockAction = ReadZSlice;
+				if( definition.RegionOfInterest is not { } region )
+					break;
+
+				_RangeX = new VolumeRange(
+					(ushort)( region.U.Start / BlockVolume.N ),
+					(ushort)( region.U.End / BlockVolume.N ) );
+				_RangeY = new VolumeRange(
+					(ushort)( region.V.Start / BlockVolume.N ),
+					(ushort)( region.V.End / BlockVolume.N ) );
+
+				break;
+			}
+
+			case Direction.Y:
+			{
+				_RangeY = new VolumeRange( blockIndex, blockIndex );
+				_BlockAction = ReadYSlice;
+
+				if( definition.RegionOfInterest is not { } region )
+					break;
+
+				_RangeX = new VolumeRange(
+					(ushort)( region.U.Start / BlockVolume.N ),
+					(ushort)( region.U.End / BlockVolume.N ) );
+				_RangeZ = new VolumeRange(
+					(ushort)( region.V.Start / BlockVolume.N ),
+					(ushort)( region.V.End / BlockVolume.N ) );
+
+				break;
+			}
+
+			case Direction.X:
+			{
+				_RangeX = new VolumeRange( blockIndex, blockIndex );
+				_BlockAction = ReadXSlice;
+
+				if( definition.RegionOfInterest is not { } region )
+					break;
+
+				_RangeY = new VolumeRange(
+					(ushort)( region.U.Start / BlockVolume.N ),
+					(ushort)( region.U.End / BlockVolume.N ) );
+				_RangeZ = new VolumeRange(
+					(ushort)( region.V.Start / BlockVolume.N ),
+					(ushort)( region.V.End / BlockVolume.N ) );
+
+				break;
+			}
+
+			default:
+				throw new ArgumentOutOfRangeException( $"Unsupported definition direction {definition.Direction}" );
+		}
+	}
+
+	#endregion
+
+	#region methods
+
+	internal void CollectSlice( IProgress<VolumeSliceDefinition>? progress, CancellationToken ct )
+	{
+		if( _Volume.CompressedData[ Direction.Z ] is not { } data )
+			throw new NotSupportedException( Resources.GetResource<Volume>( "CompressedDataMissing_ErrorText" ) );
+
+		BlockVolumeDecoder.Decode( data, _BlockAction, LayerPredicate, BlockPredicate, progress, ct );
+	}
+
+	private bool LayerPredicate( ushort layerIndex )
+	{
+		return _RangeZ.Contains( layerIndex );
+	}
+
+	private bool BlockPredicate( BlockIndex blockIndex )
+	{
+		//Z is already tested by the layer predicate
+		return _RangeX.Contains( blockIndex.X ) && _RangeY.Contains( blockIndex.Y );
+	}
+
+	private void ReadZSlice( ReadOnlySpan<byte> block, BlockIndex index )
+	{
+		var bz = _Index - index.Z * BlockVolume.N;
+		if( bz is < 0 or > BlockVolume.N )
+			throw new ArgumentOutOfRangeException( nameof( index ) );
+
+		var gz = index.Z * BlockVolume.N + bz;
+		if( gz > _SizeZ )
+			return;
+
+		var sliceData = _SliceBuffer.AsSpan();
+
+		var gx = index.X * BlockVolume.N;
+		var sx = Math.Min( BlockVolume.N, _SizeX - gx );
+
+		for( var by = 0; by < BlockVolume.N; by++ )
+		{
+			var gy = index.Y * BlockVolume.N + by;
+			if( gy >= _SizeY )
+				continue;
+
+			block.Slice( bz * BlockVolume.N2 + by * BlockVolume.N, sx ).CopyTo( sliceData.Slice( gy * _SizeX + gx, sx ) );
+		}
+	}
+
+	private void ReadYSlice( ReadOnlySpan<byte> block, BlockIndex index )
+	{
+		var by = _Index - index.Y * BlockVolume.N;
+		if( by is < 0 or > BlockVolume.N )
+			throw new ArgumentOutOfRangeException( nameof( index ) );
+
+		var gy = index.Y * BlockVolume.N + by;
+		if( gy >= _SizeY )
+			return;
+
+		var sliceData = _SliceBuffer.AsSpan();
+		var gx = index.X * BlockVolume.N;
+		var sx = Math.Min( BlockVolume.N, _SizeX - gx );
+
+		for( var bz = 0; bz < BlockVolume.N; bz++ )
+		{
+			var gz = index.Z * BlockVolume.N + bz;
+			if( gz >= _SizeZ )
+				continue;
+
+			block.Slice( bz * BlockVolume.N2 + by * BlockVolume.N, sx ).CopyTo( sliceData.Slice( gz * _SizeX + gx, sx ) );
+		}
+	}
+
+	private void ReadXSlice( ReadOnlySpan<byte> block, BlockIndex index )
+	{
+		var bx = _Index - index.X * BlockVolume.N;
+		if( bx is < 0 or > BlockVolume.N )
+			throw new ArgumentOutOfRangeException( nameof( index ) );
+
+		var gx = index.X * BlockVolume.N + bx;
+		if( gx >= _SizeX )
+			return;
+
+		var data = _SliceBuffer.AsSpan();
+
+		for( var bz = 0; bz < BlockVolume.N; bz++ )
+		{
+			var gz = index.Z * BlockVolume.N + bz;
+			if( gz >= _SizeZ )
+				continue;
+
+			for( var by = 0; by < BlockVolume.N; by++ )
+			{
+				var gy = index.Y * BlockVolume.N + by;
+				if( gy >= _SizeY )
+					continue;
+
+				data[ gz * _SizeY + gy ] = block[ bz * BlockVolume.N2 + by * BlockVolume.N + bx ];
+			}
+		}
+	}
+
+	#endregion
+}

--- a/src/PiWeb.Volume/Block/BlockVolumeSliceRangeCollector.cs
+++ b/src/PiWeb.Volume/Block/BlockVolumeSliceRangeCollector.cs
@@ -43,27 +43,6 @@ internal class BlockVolumeSliceRangeCollector
 
 	#region constructors
 
-	internal BlockVolumeSliceRangeCollector( BlockVolume volume, VolumeSliceDefinition definition, byte[] sliceBuffer )
-	{
-		_Volume = volume;
-		_Metadata = _Volume.Metadata;
-
-		_SizeZ = _Metadata.SizeZ;
-		_SizeY = _Metadata.SizeY;
-		_SizeX = _Metadata.SizeX;
-
-		var map = GetSlices( definition.Direction );
-		var block = (ushort)( definition.Index / BlockVolume.N );
-
-		map[ block ] = [new BlockSliceBuffer( definition, sliceBuffer )];
-
-		if( definition.Direction != Direction.Z && definition.RegionOfInterest.HasValue )
-			_VerticalRanges.Add( definition.RegionOfInterest.Value.V );
-
-		if( _VerticalRanges.Count == 0 && ( _SlicesX.Count > 0 || _SlicesY.Count > 0 ) )
-			_VerticalRanges.Add( new VolumeRange( 0, (ushort)( _Metadata.SizeZ - 1 ) ) );
-	}
-
 	internal BlockVolumeSliceRangeCollector( BlockVolume volume, IReadOnlyCollection<VolumeSliceRangeDefinition> ranges )
 	{
 		_Volume = volume;

--- a/src/PiWeb.Volume/Block/Quantization.cs
+++ b/src/PiWeb.Volume/Block/Quantization.cs
@@ -30,20 +30,12 @@ internal static class Quantization
 	#region methods
 
 	/// <summary>
-	/// Reads a quantization matrix from the specified <paramref name="reader"/>
+	/// Invert a quantization matrix.
 	/// </summary>
-	public static double[] Read( BinaryReader reader, bool invert )
+	public static void Invert( double[] quantization )
 	{
-		var values = new double[ BlockVolume.N3 ];
-		_ = reader.Read( MemoryMarshal.Cast<double, byte>( values.AsSpan() ) );
-
-		if( !invert )
-			return values;
-
 		for( var i = 0; i < BlockVolume.N3; i++ )
-			values[ i ] = 1.0 / values[ i ];
-
-		return values;
+			quantization[ i ] = 1.0 / quantization[ i ];
 	}
 
 	/// <summary>


### PR DESCRIPTION
* Since encoded blocks usually contain a lot of empty values, we now utilize this information to skip large parts of the decoding calculation
* The discrete cosine transform now stores the results in a way so we only need one loop to iterate
* The block metadata is now loaded from the data array using spans instead of a binary reader
* There's a new shortcut to extract single slices