### PR TITLE
feat: added the ability to decode the layers of a block volume in a specific direction

### DIFF
--- a/src/PiWeb.Volume/Block/BlockVolumeDecoder.cs
+++ b/src/PiWeb.Volume/Block/BlockVolumeDecoder.cs
@@ -30,84 +30,95 @@ internal static class BlockVolumeDecoder
 	#region methods
 
 	/// <summary>
-	/// Decodes a block volume from the given <paramref name="data"/>. The decoded blocks can be handled with the
+	/// Decodes the blocks from the given <paramref name="volume"/>. The decoded blocks can be handled with the
 	/// <paramref name="blockAction"/>. Use the <paramref name="layerPredicate"/> and
 	/// <paramref name="blockPredicate"/> to decode only specific blocks or layers.
 	/// </summary>
-	internal static void Decode( byte[] data,
+	internal static void Decode(
+		BlockVolume volume,
+		Direction direction,
 		BlockAction blockAction,
 		LayerPredicate? layerPredicate = null,
 		BlockPredicate? blockPredicate = null,
 		IProgress<VolumeSliceDefinition>? progress = null,
 		CancellationToken ct = default )
 	{
-		var header = BlockVolumeMetaData.Create( data );
-		var (_, sizeX, sizeY, sizeZ, quantization) = header;
-		var (bcx, bcy, bcz) = BlockVolume.GetBlockCount( sizeX, sizeY, sizeZ );
-		var blockCount = bcx * bcy;
-		var encodedBlockInfos = new EncodedBlockInfo[ blockCount ];
-		var position = BlockVolumeMetaData.HeaderLength;
-		var dataSpan = data.AsSpan();
+		var metaData = volume.BlockVolumeMetaData;
+		var quantization = volume.InverseQuantization;
+		var blockInfos = volume.EncodedBlockInfos;
+		var data = volume.Data;
 
-		Quantization.Invert( quantization );
+		var (bcx, bcy, bcz) = metaData.GetBlockCount();
+		var layerCount = metaData.GetBlockCount( direction );
+		var (u, v) = metaData.GetLayerBlockCount( direction );
+		var blockInfoLayer = new BlockVolume.EncodedBlockInfo[ u * v ];
 
-		for( ushort biz = 0; biz < bcz; biz++ )
+		for( ushort layer = 0; layer < layerCount; layer++ )
 		{
 			ct.ThrowIfCancellationRequested();
-
-			var layerLength = MemoryMarshal.Read<int>( dataSpan.Slice( position, sizeof( int ) ) );
-			position += sizeof( int );
-			if( layerPredicate?.Invoke( biz ) is false )
-			{
-				position += layerLength;
+			if( layerPredicate?.Invoke( layer ) is false )
 				continue;
-			}
 
-			ReadLayer( dataSpan, position, blockCount, encodedBlockInfos );
-			DecodeLayer( data, encodedBlockInfos, bcx, bcy, biz, quantization, blockPredicate, blockAction );
+			GetBlockInfoLayer( direction, layer, bcx, bcy, bcz, blockInfos, blockInfoLayer );
+			DecodeLayer( data, blockInfoLayer, direction, u, layer, quantization, blockPredicate, blockAction );
 
-			progress?.Report( new VolumeSliceDefinition( Direction.Z, (ushort)( biz * BlockVolume.N ) ) );
-
-			position += layerLength;
+			progress?.Report( new VolumeSliceDefinition( Direction.Z, (ushort)( layer * BlockVolume.N ) ) );
 		}
 	}
 
-	private static void ReadLayer( ReadOnlySpan<byte> dataSpan, int position, int blockCount, EncodedBlockInfo[] encodedBlockInfos )
+	private static void GetBlockInfoLayer(
+		Direction direction,
+		ushort layer,
+		ushort bcx,
+		ushort bcy,
+		ushort bcz,
+		ReadOnlySpan<BlockVolume.EncodedBlockInfo> allInfos,
+		BlockVolume.EncodedBlockInfo[] blockInfoLayer )
 	{
-		for( var i = 0; i < blockCount; i++ )
+		switch( direction )
 		{
-			var value = MemoryMarshal.Read<ushort>( dataSpan[ position.. ] );
-
-			position += sizeof( ushort );
-
-			var encodedBlockInfo = new EncodedBlockInfo( position, BlockInfo.Create( value ) );
-			encodedBlockInfos[ i ] = encodedBlockInfo;
-
-			position += encodedBlockInfo.Info.Length;
+			case Direction.Z:
+				allInfos.Slice( layer * bcx * bcy, bcx * bcy ).CopyTo( blockInfoLayer.AsSpan() );
+				break;
+			case Direction.Y:
+				for( var z = 0; z < bcz; z++ )
+					allInfos.Slice( z * bcx * bcy + layer * bcx, bcx ).CopyTo( blockInfoLayer.AsSpan().Slice( z * bcx, bcx ) );
+				break;
+			case Direction.X:
+				for( var z = 0; z < bcz; z++ )
+				for( var y = 0; y < bcy; y++ )
+					blockInfoLayer[ z * bcy + y ] = allInfos[ z * bcx * bcy + y * bcx + layer ];
+				break;
+			default:
+				throw new ArgumentOutOfRangeException( nameof( direction ), direction, null );
 		}
 	}
 
 	private static void DecodeLayer(
 		byte[] encodedBlocks,
-		EncodedBlockInfo[] encodedBlockInfos,
-		ushort blockCountX,
-		ushort blockCountY,
-		ushort blockIndexZ,
+		BlockVolume.EncodedBlockInfo[] encodedBlockInfos,
+		Direction direction,
+		ushort stride,
+		ushort layerIndex,
 		double[] quantization,
 		BlockPredicate? blockPredicate,
 		BlockAction blockAction )
 	{
 #if DEBUG
 		var buffers = new DecodingBuffers();
-		for( var index = 0; index < blockCountX * blockCountY; index++ )
+		for( var index = 0; index < encodedBlockInfos.Length; index++ )
 		{
 #else
-		Parallel.For( 0, blockCountX * blockCountY, () => new DecodingBuffers(), ( index, _, buffers ) =>
+		Parallel.For( 0, encodedBlockInfos.Length, () => new DecodingBuffers(), ( index, _, buffers ) =>
 		{
 #endif
-			var blockIndexX = index % blockCountX;
-			var blockIndexY = index / blockCountX;
-			var blockIndex = new BlockIndex( (ushort)blockIndexX, (ushort)blockIndexY, blockIndexZ );
+			var blockIndex = direction switch
+			{
+				Direction.X => new BlockIndex( layerIndex, (ushort)( index % stride ), (ushort)( index / stride ) ),
+				Direction.Y => new BlockIndex( (ushort)( index % stride ), layerIndex, (ushort)( index / stride ) ),
+				Direction.Z => new BlockIndex( (ushort)( index % stride ), (ushort)( index / stride ), layerIndex ),
+				_           => throw new ArgumentOutOfRangeException( nameof( direction ), direction, null )
+			};
 
 			if( blockPredicate?.Invoke( blockIndex ) == false )
 #if DEBUG
@@ -164,7 +175,7 @@ internal static class BlockVolumeDecoder
 		return result;
 	}
 
-	private static void ReadBlock( ReadOnlySpan<byte> data, EncodedBlockInfo blockInfo, Span<double> result )
+	private static void ReadBlock( ReadOnlySpan<byte> data, BlockVolume.EncodedBlockInfo blockInfo, Span<double> result )
 	{
 		var length = blockInfo.Info.Length;
 		var encodedBlockData = data.Slice( blockInfo.StartIndex, length );
@@ -213,8 +224,6 @@ internal static class BlockVolumeDecoder
 			ArrayPool<byte>.Shared.Return( ResultBuffer );
 		}
 	}
-
-	private readonly record struct EncodedBlockInfo( int StartIndex, BlockInfo Info );
 
 	internal delegate void BlockAction( ReadOnlySpan<byte> data, BlockIndex index );
 

--- a/src/PiWeb.Volume/Block/BlockVolumeDecompressor.cs
+++ b/src/PiWeb.Volume/Block/BlockVolumeDecompressor.cs
@@ -57,10 +57,7 @@ internal class BlockVolumeDecompressor
 	/// </summary>
 	internal VolumeSlice[] Decompress( IProgress<VolumeSliceDefinition>? progress = null, CancellationToken ct = default )
 	{
-		if( _Volume.CompressedData[ Direction.Z ] is not { } data )
-			throw new NotSupportedException( Resources.GetResource<Volume>( "CompressedDataMissing_ErrorText" ) );
-
-		BlockVolumeDecoder.Decode( data, CopyBlockToResult, null, null, progress, ct );
+		BlockVolumeDecoder.Decode( _Volume, Direction.Z, CopyBlockToResult, null, null, progress, ct );
 
 		return _Result
 			.AsParallel()

--- a/src/PiWeb.Volume/Block/BlockVolumeEncoder.cs
+++ b/src/PiWeb.Volume/Block/BlockVolumeEncoder.cs
@@ -73,7 +73,7 @@ internal static class BlockVolumeEncoder
 	private static IEnumerable<byte[][]> EnumerateBlockLayersFromStream( Stream input, BlockVolumeMetaData metadata )
 	{
 		var z = 0;
-		var (_, _, layerCount) = BlockVolume.GetBlockCount( metadata );
+		var (_, _, layerCount) = metadata.GetBlockCount();
 		var layerBuffer = new byte[ BlockVolume.N ][];
 		var layerLength = metadata.SizeX * metadata.SizeY;
 
@@ -96,7 +96,7 @@ internal static class BlockVolumeEncoder
 	{
 		var z = 0;
 		var buffer = new byte[ BlockVolume.N ][];
-		var (_, _, layerCount) = BlockVolume.GetBlockCount( metadata );
+		var (_, _, layerCount) = metadata.GetBlockCount();
 
 		for( var layerIndex = 0; layerIndex < layerCount; layerIndex++ )
 		{
@@ -109,7 +109,7 @@ internal static class BlockVolumeEncoder
 
 	private static void Encode( IEnumerable<byte[][]> blockLayers, Stream output, BlockVolumeMetaData metadata, IProgress<VolumeSliceDefinition>? progress )
 	{
-		var (bcx, bcy, _) = BlockVolume.GetBlockCount( metadata );
+		var (bcx, bcy, _) = metadata.GetBlockCount();
 
 		var blockCount = bcx * bcy;
 		var inputBlocks = new double[ blockCount ][];
@@ -231,7 +231,7 @@ internal static class BlockVolumeEncoder
 		var sy = metadata.SizeY;
 		var sz = metadata.SizeZ;
 
-		var (bcx, bcy, _) = BlockVolume.GetBlockCount( metadata );
+		var (bcx, bcy, _) = metadata.GetBlockCount();
 
 		Parallel.For( 0, bcx * bcy, blockIndex =>
 		{

--- a/src/PiWeb.Volume/Block/BlockVolumeMetaData.cs
+++ b/src/PiWeb.Volume/Block/BlockVolumeMetaData.cs
@@ -70,6 +70,41 @@ public record BlockVolumeMetaData( uint Version, ushort SizeX, ushort SizeY, ush
 
 	#endregion
 
+	internal (ushort, ushort, ushort) GetBlockCount()
+	{
+		return ( GetBlockCount( Direction.X ),
+			GetBlockCount( Direction.Y ),
+			GetBlockCount( Direction.Z ) );
+	}
+
+	internal ushort GetBlockCount( Direction direction )
+	{
+		var size = direction switch
+		{
+			Direction.X => SizeX,
+			Direction.Y => SizeY,
+			Direction.Z => SizeZ,
+			_           => throw new ArgumentOutOfRangeException( nameof( direction ), direction, null )
+		};
+
+		var blocks = size / BlockVolume.N;
+		if( blocks * BlockVolume.N < size )
+			blocks++;
+
+		return (ushort)blocks;
+	}
+
+	internal (ushort, ushort) GetLayerBlockCount( Direction direction )
+	{
+		return direction switch
+		{
+			Direction.X => ( GetBlockCount( Direction.Y ), GetBlockCount( Direction.Z ) ),
+			Direction.Y => ( GetBlockCount( Direction.X ), GetBlockCount( Direction.Z ) ),
+			Direction.Z => ( GetBlockCount( Direction.X ), GetBlockCount( Direction.Y ) ),
+			_           => throw new ArgumentOutOfRangeException( nameof( direction ), direction, null )
+		};
+	}
+
 	/// <summary>
 	/// The number of bytes the header consists of.
 	/// </summary>

--- a/src/PiWeb.Volume/Block/BlockVolumePreviewCreator.cs
+++ b/src/PiWeb.Volume/Block/BlockVolumePreviewCreator.cs
@@ -66,12 +66,9 @@ internal class BlockVolumePreviewCreator
 
 	internal UncompressedVolume CreatePreview( IProgress<VolumeSliceDefinition>? progress, CancellationToken ct )
 	{
-		if( _Volume.CompressedData[ Direction.Z ] is not {} data )
-			throw new NotSupportedException( Resources.GetResource<Volume>( "CompressedDataMissing_ErrorText" ) );
-
 		var result = VolumeSliceHelper.CreateSliceBuffer( _PreviewSizeX, _PreviewSizeY, _PreviewSizeZ );
 
-		BlockVolumeDecoder.Decode( data, ( block, index ) =>
+		BlockVolumeDecoder.Decode( _Volume, Direction.Z, ( block, index ) =>
 		{
 			for( var bz = 0; bz < BlockVolume.N; bz++ )
 			for( var by = 0; by < BlockVolume.N; by++ )

--- a/src/PiWeb.Volume/Block/BlockVolumeSliceRangeCollector.cs
+++ b/src/PiWeb.Volume/Block/BlockVolumeSliceRangeCollector.cs
@@ -97,10 +97,7 @@ internal class BlockVolumeSliceRangeCollector
 
 	internal VolumeSliceCollection CollectSliceRanges( IProgress<VolumeSliceDefinition>? progress, CancellationToken ct )
 	{
-		if( _Volume.CompressedData[ Direction.Z ] is not { } data )
-			throw new NotSupportedException( Resources.GetResource<Volume>( "CompressedDataMissing_ErrorText" ) );
-
-		BlockVolumeDecoder.Decode( data, BlockAction, LayerPredicate, BlockPredicate, progress, ct );
+		BlockVolumeDecoder.Decode( _Volume, Direction.Z, BlockAction, LayerPredicate, BlockPredicate, progress, ct );
 
 		return new VolumeSliceCollection(
 			_SlicesX.Values

--- a/src/PiWeb.Volume/Block/Quantization.cs
+++ b/src/PiWeb.Volume/Block/Quantization.cs
@@ -32,10 +32,13 @@ internal static class Quantization
 	/// <summary>
 	/// Invert a quantization matrix.
 	/// </summary>
-	public static void Invert( double[] quantization )
+	public static double[] Invert( double[] quantization )
 	{
+		var result = new double[ quantization.Length ];
 		for( var i = 0; i < BlockVolume.N3; i++ )
-			quantization[ i ] = 1.0 / quantization[ i ];
+			result[ i ] = 1.0 / quantization[ i ];
+
+		return result;
 	}
 
 	/// <summary>


### PR DESCRIPTION
Before, the decoder was always scanning through the volume in Z direction and skipped all layers and blocks that were not necessary. When extracting Y- and X-slices, no layers could be skipped and we had to skip block by block. After that, only one column or row of blocks would be decoded in parallel, all other blocks were skipped.

This PR allows scanning the volume in the two other directions so we can quickly jump to the required layer. Also, the blocks of the required layer are all decoded in parallel.

The decoding performance of single slices in all directions is pretty much equal with this PR.