### PR TITLE
Cleanup code

### DIFF
--- a/src/PiWeb.Volume.UI/Components/Navigator.cs
+++ b/src/PiWeb.Volume.UI/Components/Navigator.cs
@@ -27,45 +27,45 @@ namespace Zeiss.PiWeb.Volume.UI.Components
         #region members
 
         public static readonly DependencyProperty ZoomProperty =
-            DependencyProperty.Register( "Zoom", typeof( double ), typeof( Navigator ), new PropertyMetadata( 1.0, OnZoomChanged ) );
+            DependencyProperty.Register( nameof(Zoom), typeof( double ), typeof( Navigator ), new PropertyMetadata( 1.0, OnZoomChanged ) );
 
         public static readonly DependencyProperty MinZoomProperty =
-            DependencyProperty.Register( "MinZoom", typeof( double ), typeof( Navigator ), new PropertyMetadata( 0.1 ) );
+            DependencyProperty.Register( nameof(MinZoom), typeof( double ), typeof( Navigator ), new PropertyMetadata( 0.1 ) );
 
         public static readonly DependencyProperty MaxZoomProperty =
-            DependencyProperty.Register( "MaxZoom", typeof( double ), typeof( Navigator ), new PropertyMetadata( 7.5 ) );
+            DependencyProperty.Register( nameof(MaxZoom), typeof( double ), typeof( Navigator ), new PropertyMetadata( 7.5 ) );
 
         public static readonly DependencyProperty ZoomMarginProperty =
-            DependencyProperty.Register( "ZoomMargin", typeof( Thickness ), typeof( Navigator ), new PropertyMetadata( new Thickness( 15 ), OnZoomMarginChanged ) );
+            DependencyProperty.Register( nameof(ZoomMargin), typeof( Thickness ), typeof( Navigator ), new PropertyMetadata( new Thickness( 15 ), OnZoomMarginChanged ) );
 
         public static readonly DependencyProperty ZoomModifierKeyProperty =
-            DependencyProperty.Register( "ZoomModifierKey", typeof( ModifierKeys ), typeof( Navigator ), new PropertyMetadata( ModifierKeys.Control ) );
+            DependencyProperty.Register( nameof(ZoomModifierKey), typeof( ModifierKeys ), typeof( Navigator ), new PropertyMetadata( ModifierKeys.Control ) );
 
-        public static readonly DependencyProperty IsZoomEnabledProperty =
-            DependencyProperty.Register( "IsZoomEnabled", typeof( bool ), typeof( Navigator ),
-                                         new PropertyMetadata( false ) );
+		public static readonly DependencyProperty IsZoomEnabledProperty =
+			DependencyProperty.Register( nameof( IsZoomEnabled ), typeof( bool ), typeof( Navigator ),
+				new PropertyMetadata( false ) );
 
-        public static readonly DependencyProperty IsPanningEnabledProperty =
-            DependencyProperty.Register( "IsPanningEnabled", typeof( bool ), typeof( Navigator ),
-                                         new PropertyMetadata( false ) );
+		public static readonly DependencyProperty IsPanningEnabledProperty =
+			DependencyProperty.Register( nameof( IsPanningEnabled ), typeof( bool ), typeof( Navigator ),
+				new PropertyMetadata( false ) );
 
         public static readonly DependencyProperty PanButtonProperty =
-            DependencyProperty.Register( "PanButton", typeof( MouseButton ), typeof( Navigator ), new PropertyMetadata( MouseButton.Right ) );
+            DependencyProperty.Register( nameof(PanButton), typeof( MouseButton ), typeof( Navigator ), new PropertyMetadata( MouseButton.Right ) );
 
         public static readonly DependencyProperty HorizontalPanningProperty = DependencyProperty.Register(
-            "HorizontalPanning", typeof( double ), typeof( Navigator ), new PropertyMetadata( 0, OnHorizontalPanningChanged ) );
+            nameof(HorizontalPanning), typeof( double ), typeof( Navigator ), new PropertyMetadata( 0, OnHorizontalPanningChanged ) );
 
         public static readonly DependencyProperty VerticalPanningProperty = DependencyProperty.Register(
-            "VerticalPanning", typeof( double ), typeof( Navigator ), new PropertyMetadata( 0, OnVerticelPanningChanged ) );
+            nameof(VerticalPanning), typeof( double ), typeof( Navigator ), new PropertyMetadata( 0, OnVerticelPanningChanged ) );
 
         public static readonly DependencyProperty FitProperty = DependencyProperty.Register(
-            "Fit", typeof( Rect ), typeof( Navigator ), new PropertyMetadata( Rect.Empty, OnFitChanged ) );
+            nameof(Fit), typeof( Rect ), typeof( Navigator ), new PropertyMetadata( Rect.Empty, OnFitChanged ) );
 
-        public static readonly DependencyProperty HorizontalRangeProperty = DependencyProperty.Register(
-            "HorizontalRange", typeof( DoubleRange ), typeof( Navigator ), new PropertyMetadata( default( DoubleRange ) ) );
+		public static readonly DependencyProperty HorizontalRangeProperty = DependencyProperty.Register(
+			nameof( HorizontalRange ), typeof( DoubleRange ), typeof( Navigator ), new PropertyMetadata( default( DoubleRange ) ) );
 
-        public static readonly DependencyProperty VerticalRangeProperty = DependencyProperty.Register(
-            "VerticalRange", typeof( DoubleRange ), typeof( Navigator ), new PropertyMetadata( default( DoubleRange ) ) );
+		public static readonly DependencyProperty VerticalRangeProperty = DependencyProperty.Register(
+			nameof( VerticalRange ), typeof( DoubleRange ), typeof( Navigator ), new PropertyMetadata( default( DoubleRange ) ) );
 
 
         public static readonly ICommand ZoomToContentSizeCommand = new RelayCommand<Navigator>( ExecuteZoomToContentSize );

--- a/src/PiWeb.Volume.UI/Components/Navigator.cs
+++ b/src/PiWeb.Volume.UI/Components/Navigator.cs
@@ -53,10 +53,10 @@ namespace Zeiss.PiWeb.Volume.UI.Components
             DependencyProperty.Register( "PanButton", typeof( MouseButton ), typeof( Navigator ), new PropertyMetadata( MouseButton.Right ) );
 
         public static readonly DependencyProperty HorizontalPanningProperty = DependencyProperty.Register(
-            "HorizontalPanning", typeof( double ), typeof( Navigator ), new PropertyMetadata( default( double ), OnHorizontalPanningChanged ) );
+            "HorizontalPanning", typeof( double ), typeof( Navigator ), new PropertyMetadata( 0, OnHorizontalPanningChanged ) );
 
         public static readonly DependencyProperty VerticalPanningProperty = DependencyProperty.Register(
-            "VerticalPanning", typeof( double ), typeof( Navigator ), new PropertyMetadata( default( double ), OnVerticelPanningChanged ) );
+            "VerticalPanning", typeof( double ), typeof( Navigator ), new PropertyMetadata( 0, OnVerticelPanningChanged ) );
 
         public static readonly DependencyProperty FitProperty = DependencyProperty.Register(
             "Fit", typeof( Rect ), typeof( Navigator ), new PropertyMetadata( Rect.Empty, OnFitChanged ) );

--- a/src/PiWeb.Volume.UI/Components/Ruler.cs
+++ b/src/PiWeb.Volume.UI/Components/Ruler.cs
@@ -26,33 +26,33 @@ namespace Zeiss.PiWeb.Volume.UI.Components
     {
         #region members
 
-        public static DependencyProperty ValueRangeProperty =
-            DependencyProperty.Register( "ValueRange", typeof( DoubleRange? ), typeof( Ruler ), new FrameworkPropertyMetadata( null, FrameworkPropertyMetadataOptions.AffectsRender )
-            );
+		public static readonly DependencyProperty ValueRangeProperty =
+			DependencyProperty.Register( nameof( ValueRange ), typeof( DoubleRange? ), typeof( Ruler ), new FrameworkPropertyMetadata( null, FrameworkPropertyMetadataOptions.AffectsRender )
+			);
 
-        public static DependencyProperty StrokeThicknessProperty =
-            DependencyProperty.Register( "StrokeThickness", typeof( double ), typeof( Ruler ), new FrameworkPropertyMetadata( 1.0, FrameworkPropertyMetadataOptions.AffectsRender )
-            );
+		public static readonly DependencyProperty StrokeThicknessProperty =
+			DependencyProperty.Register( nameof( StrokeThickness ), typeof( double ), typeof( Ruler ), new FrameworkPropertyMetadata( 1.0, FrameworkPropertyMetadataOptions.AffectsRender )
+			);
 
-        public static DependencyProperty StrokeProperty =
-            DependencyProperty.Register( "Stroke", typeof( Brush ), typeof( Ruler ), new FrameworkPropertyMetadata( Brushes.Black, FrameworkPropertyMetadataOptions.AffectsRender ) );
+		public static readonly DependencyProperty StrokeProperty =
+			DependencyProperty.Register( nameof( Stroke ), typeof( Brush ), typeof( Ruler ), new FrameworkPropertyMetadata( Brushes.Black, FrameworkPropertyMetadataOptions.AffectsRender ) );
 
-        public static DependencyProperty InvertProperty =
-            DependencyProperty.Register( "Invert", typeof( bool ), typeof( Ruler ), new FrameworkPropertyMetadata( false, FrameworkPropertyMetadataOptions.AffectsRender )
-            );
+		public static readonly DependencyProperty InvertProperty =
+			DependencyProperty.Register( nameof( Invert ), typeof( bool ), typeof( Ruler ), new FrameworkPropertyMetadata( false, FrameworkPropertyMetadataOptions.AffectsRender )
+			);
 
-        public static DependencyProperty HighlightBrushProperty =
-            DependencyProperty.Register( "HighlightBrush", typeof( Brush ), typeof( Ruler ), new FrameworkPropertyMetadata( Brushes.White, FrameworkPropertyMetadataOptions.AffectsRender )
-            );
+		public static readonly DependencyProperty HighlightBrushProperty =
+			DependencyProperty.Register( nameof( HighlightBrush ), typeof( Brush ), typeof( Ruler ), new FrameworkPropertyMetadata( Brushes.White, FrameworkPropertyMetadataOptions.AffectsRender )
+			);
 
 
-        public static DependencyProperty HighlightedRangeProperty =
-            DependencyProperty.Register( "HighlightedRange", typeof( DoubleRange? ), typeof( Ruler ), new FrameworkPropertyMetadata( null, FrameworkPropertyMetadataOptions.AffectsRender )
-            );
+		public static readonly DependencyProperty HighlightedRangeProperty =
+			DependencyProperty.Register( nameof( HighlightedRange ), typeof( DoubleRange? ), typeof( Ruler ), new FrameworkPropertyMetadata( null, FrameworkPropertyMetadataOptions.AffectsRender )
+			);
 
-        public static DependencyProperty OrientationProperty =
-            DependencyProperty.Register( "Orientation", typeof( Orientation ), typeof( Ruler ), new FrameworkPropertyMetadata( Orientation.Horizontal, FrameworkPropertyMetadataOptions.AffectsRender )
-            );
+		public static readonly DependencyProperty OrientationProperty =
+			DependencyProperty.Register( nameof( Orientation ), typeof( Orientation ), typeof( Ruler ), new FrameworkPropertyMetadata( Orientation.Horizontal, FrameworkPropertyMetadataOptions.AffectsRender )
+			);
 
         #endregion
 

--- a/src/PiWeb.Volume.UI/Components/Spectrum.cs
+++ b/src/PiWeb.Volume.UI/Components/Spectrum.cs
@@ -28,10 +28,10 @@ namespace Zeiss.PiWeb.Volume.UI.Components
 		#region members
 
 		public static readonly DependencyProperty DataProperty = DependencyProperty.Register(
-			"Data", typeof( IReadOnlyCollection<SpectrumData> ), typeof( Spectrum ), new FrameworkPropertyMetadata( null, FrameworkPropertyMetadataOptions.AffectsRender ) );
+			nameof(Data), typeof( IReadOnlyCollection<SpectrumData> ), typeof( Spectrum ), new FrameworkPropertyMetadata( null, FrameworkPropertyMetadataOptions.AffectsRender ) );
 
 		public static readonly DependencyProperty LogarithmicScaleProperty = DependencyProperty.Register(
-			"LogarithmicScale", typeof( bool ), typeof( Spectrum ), new FrameworkPropertyMetadata( false, FrameworkPropertyMetadataOptions.AffectsRender ) );
+			nameof(LogarithmicScale), typeof( bool ), typeof( Spectrum ), new FrameworkPropertyMetadata( false, FrameworkPropertyMetadataOptions.AffectsRender ) );
 
 		private int? _HighlightedIndex;
 

--- a/src/PiWeb.Volume.UI/Components/Spectrum.cs
+++ b/src/PiWeb.Volume.UI/Components/Spectrum.cs
@@ -28,10 +28,10 @@ namespace Zeiss.PiWeb.Volume.UI.Components
 		#region members
 
 		public static readonly DependencyProperty DataProperty = DependencyProperty.Register(
-			"Data", typeof( IReadOnlyCollection<SpectrumData> ), typeof( Spectrum ), new FrameworkPropertyMetadata( default( IReadOnlyCollection<SpectrumData> ), FrameworkPropertyMetadataOptions.AffectsRender ) );
+			"Data", typeof( IReadOnlyCollection<SpectrumData> ), typeof( Spectrum ), new FrameworkPropertyMetadata( null, FrameworkPropertyMetadataOptions.AffectsRender ) );
 
 		public static readonly DependencyProperty LogarithmicScaleProperty = DependencyProperty.Register(
-			"LogarithmicScale", typeof( bool ), typeof( Spectrum ), new FrameworkPropertyMetadata( default( bool ), FrameworkPropertyMetadataOptions.AffectsRender ) );
+			"LogarithmicScale", typeof( bool ), typeof( Spectrum ), new FrameworkPropertyMetadata( false, FrameworkPropertyMetadataOptions.AffectsRender ) );
 
 		private int? _HighlightedIndex;
 

--- a/src/PiWeb.Volume.UI/Components/VolumeDirectionButton.cs
+++ b/src/PiWeb.Volume.UI/Components/VolumeDirectionButton.cs
@@ -23,13 +23,13 @@ namespace Zeiss.PiWeb.Volume.UI.Components
         #region members
 
         public static readonly DependencyProperty OuterPathProperty = DependencyProperty.Register(
-            "OuterPath", typeof( Geometry ), typeof( VolumeDirectionButton ), new PropertyMetadata( default( Geometry ) ) );
+            nameof(OuterPath), typeof( Geometry ), typeof( VolumeDirectionButton ), new PropertyMetadata( default( Geometry ) ) );
 
         public static readonly DependencyProperty InnerPathProperty = DependencyProperty.Register(
-            "InnerPath", typeof( Geometry ), typeof( VolumeDirectionButton ), new PropertyMetadata( default( Geometry ) ) );
+            nameof(InnerPath), typeof( Geometry ), typeof( VolumeDirectionButton ), new PropertyMetadata( default( Geometry ) ) );
 
         public static readonly DependencyProperty IsSelectedProperty = DependencyProperty.Register(
-            "IsSelected", typeof( bool ), typeof( VolumeDirectionButton ), new PropertyMetadata( false ) );
+            nameof(IsSelected), typeof( bool ), typeof( VolumeDirectionButton ), new PropertyMetadata( false ) );
 
         #endregion
 

--- a/src/PiWeb.Volume.UI/Components/VolumeDirectionButton.cs
+++ b/src/PiWeb.Volume.UI/Components/VolumeDirectionButton.cs
@@ -29,7 +29,7 @@ namespace Zeiss.PiWeb.Volume.UI.Components
             "InnerPath", typeof( Geometry ), typeof( VolumeDirectionButton ), new PropertyMetadata( default( Geometry ) ) );
 
         public static readonly DependencyProperty IsSelectedProperty = DependencyProperty.Register(
-            "IsSelected", typeof( bool ), typeof( VolumeDirectionButton ), new PropertyMetadata( default( bool ) ) );
+            "IsSelected", typeof( bool ), typeof( VolumeDirectionButton ), new PropertyMetadata( false ) );
 
         #endregion
 

--- a/src/PiWeb.Volume.UI/Effects/ContrastEffect.cs
+++ b/src/PiWeb.Volume.UI/Effects/ContrastEffect.cs
@@ -23,9 +23,9 @@ namespace Zeiss.PiWeb.Volume.UI.Effects
 	{
 		#region members
 
-		public static readonly DependencyProperty InputProperty = RegisterPixelShaderSamplerProperty( "Input", typeof( ContrastEffect ), 0 );
-		public static readonly DependencyProperty LowProperty = DependencyProperty.Register( "Low", typeof( double ), typeof( ContrastEffect ), new UIPropertyMetadata( 0.0, PixelShaderConstantCallback( 0 ) ) );
-		public static readonly DependencyProperty HighProperty = DependencyProperty.Register( "High", typeof( double ), typeof( ContrastEffect ), new UIPropertyMetadata( 1.0, PixelShaderConstantCallback( 1 ) ) );
+		public static readonly DependencyProperty InputProperty = RegisterPixelShaderSamplerProperty( nameof( Input ), typeof( ContrastEffect ), 0 );
+		public static readonly DependencyProperty LowProperty = DependencyProperty.Register( nameof( Low ), typeof( double ), typeof( ContrastEffect ), new UIPropertyMetadata( 0.0, PixelShaderConstantCallback( 0 ) ) );
+		public static readonly DependencyProperty HighProperty = DependencyProperty.Register( nameof( High ), typeof( double ), typeof( ContrastEffect ), new UIPropertyMetadata( 1.0, PixelShaderConstantCallback( 1 ) ) );
 
 		#endregion
 

--- a/src/PiWeb.Volume.UI/Effects/DeltaEffect.cs
+++ b/src/PiWeb.Volume.UI/Effects/DeltaEffect.cs
@@ -23,14 +23,14 @@ namespace Zeiss.PiWeb.Volume.UI.Effects
 	{
 		#region members
 
-		public static readonly DependencyProperty InputProperty = RegisterPixelShaderSamplerProperty( "Input", typeof( DeltaEffect ), 0 );
-		public static readonly DependencyProperty LeftProperty = RegisterPixelShaderSamplerProperty( "Left", typeof( DeltaEffect ), 1 );
-		public static readonly DependencyProperty RightProperty = RegisterPixelShaderSamplerProperty( "Right", typeof( DeltaEffect ), 2 );
-		public static readonly DependencyProperty MinColorProperty = DependencyProperty.Register( "MinColor", typeof( Color ), typeof( DeltaEffect ), new UIPropertyMetadata( Color.FromArgb( 255, 0, 128, 0 ), PixelShaderConstantCallback( 1 ) ) );
-		public static readonly DependencyProperty MidColorProperty = DependencyProperty.Register( "MidColor", typeof( Color ), typeof( DeltaEffect ), new UIPropertyMetadata( Color.FromArgb( 255, 255, 255, 0 ), PixelShaderConstantCallback( 2 ) ) );
-		public static readonly DependencyProperty MaxColorProperty = DependencyProperty.Register( "MaxColor", typeof( Color ), typeof( DeltaEffect ), new UIPropertyMetadata( Color.FromArgb( 255, 255, 0, 0 ), PixelShaderConstantCallback( 3 ) ) );
-		public static readonly DependencyProperty MinProperty = DependencyProperty.Register( "Min", typeof( double ), typeof( DeltaEffect ), new UIPropertyMetadata( 0.02D, PixelShaderConstantCallback( 4 ) ) );
-		public static readonly DependencyProperty MaxProperty = DependencyProperty.Register( "Max", typeof( double ), typeof( DeltaEffect ), new UIPropertyMetadata( 0.05D, PixelShaderConstantCallback( 5 ) ) );
+		public static readonly DependencyProperty InputProperty = RegisterPixelShaderSamplerProperty( nameof( Input ), typeof( DeltaEffect ), 0 );
+		public static readonly DependencyProperty LeftProperty = RegisterPixelShaderSamplerProperty( nameof( Left ), typeof( DeltaEffect ), 1 );
+		public static readonly DependencyProperty RightProperty = RegisterPixelShaderSamplerProperty( nameof( Right ), typeof( DeltaEffect ), 2 );
+		public static readonly DependencyProperty MinColorProperty = DependencyProperty.Register( nameof( MinColor ), typeof( Color ), typeof( DeltaEffect ), new UIPropertyMetadata( Color.FromArgb( 255, 0, 128, 0 ), PixelShaderConstantCallback( 1 ) ) );
+		public static readonly DependencyProperty MidColorProperty = DependencyProperty.Register( nameof( MidColor ), typeof( Color ), typeof( DeltaEffect ), new UIPropertyMetadata( Color.FromArgb( 255, 255, 255, 0 ), PixelShaderConstantCallback( 2 ) ) );
+		public static readonly DependencyProperty MaxColorProperty = DependencyProperty.Register( nameof( MaxColor ), typeof( Color ), typeof( DeltaEffect ), new UIPropertyMetadata( Color.FromArgb( 255, 255, 0, 0 ), PixelShaderConstantCallback( 3 ) ) );
+		public static readonly DependencyProperty MinProperty = DependencyProperty.Register( nameof( Min ), typeof( double ), typeof( DeltaEffect ), new UIPropertyMetadata( 0.02D, PixelShaderConstantCallback( 4 ) ) );
+		public static readonly DependencyProperty MaxProperty = DependencyProperty.Register( nameof( Max ), typeof( double ), typeof( DeltaEffect ), new UIPropertyMetadata( 0.05D, PixelShaderConstantCallback( 5 ) ) );
 
 		#endregion
 

--- a/src/PiWeb.Volume.UI/Effects/GrayscaleEffect.cs
+++ b/src/PiWeb.Volume.UI/Effects/GrayscaleEffect.cs
@@ -23,11 +23,11 @@ namespace Zeiss.PiWeb.Volume.UI.Effects
     {
         #region members
 
-        public static readonly DependencyProperty InputProperty = RegisterPixelShaderSamplerProperty( "Input", typeof( GrayscaleEffect ), 0 );
-        public static readonly DependencyProperty RProperty = DependencyProperty.Register( "R", typeof( double ), typeof( GrayscaleEffect ), new UIPropertyMetadata( 0.299, PixelShaderConstantCallback( 0 ) ) );
-        public static readonly DependencyProperty GProperty = DependencyProperty.Register( "G", typeof( double ), typeof( GrayscaleEffect ), new UIPropertyMetadata( 0.587, PixelShaderConstantCallback( 1 ) ) );
-        public static readonly DependencyProperty BProperty = DependencyProperty.Register( "B", typeof( double ), typeof( GrayscaleEffect ), new UIPropertyMetadata( 0.144, PixelShaderConstantCallback( 2 ) ) );
-        public static readonly DependencyProperty OpacityProperty = DependencyProperty.Register( "Opacity", typeof( double ), typeof( GrayscaleEffect ), new UIPropertyMetadata( 1D, PixelShaderConstantCallback( 3 ) ) );
+        public static readonly DependencyProperty InputProperty = RegisterPixelShaderSamplerProperty( nameof( Input ), typeof( GrayscaleEffect ), 0 );
+		public static readonly DependencyProperty RProperty = DependencyProperty.Register( nameof( R ), typeof( double ), typeof( GrayscaleEffect ), new UIPropertyMetadata( 0.299, PixelShaderConstantCallback( 0 ) ) );
+		public static readonly DependencyProperty GProperty = DependencyProperty.Register( nameof( G ), typeof( double ), typeof( GrayscaleEffect ), new UIPropertyMetadata( 0.587, PixelShaderConstantCallback( 1 ) ) );
+		public static readonly DependencyProperty BProperty = DependencyProperty.Register( nameof( B ), typeof( double ), typeof( GrayscaleEffect ), new UIPropertyMetadata( 0.144, PixelShaderConstantCallback( 2 ) ) );
+		public static readonly DependencyProperty OpacityProperty = DependencyProperty.Register( nameof( Opacity ), typeof( double ), typeof( GrayscaleEffect ), new UIPropertyMetadata( 1D, PixelShaderConstantCallback( 3 ) ) );
 
         #endregion
 

--- a/src/PiWeb.Volume/Block/DiscreteCosineTransform.cs
+++ b/src/PiWeb.Volume/Block/DiscreteCosineTransform.cs
@@ -78,9 +78,9 @@ internal static class DiscreteCosineTransform
 	}
 
 	private static ulong TransformDirection(
-		Span<Vector512<double>> inputVectors,
+		ReadOnlySpan<Vector512<double>> inputVectors,
 		Span<double> result,
-		Span<Vector512<double>> coefficients,
+		ReadOnlySpan<Vector512<double>> coefficients,
 		ulong nonEmptyInputVectors )
 	{
 		result.Clear();
@@ -95,14 +95,14 @@ internal static class DiscreteCosineTransform
 			var input = inputVectors[ p ];
 
 			//This loop is unrolled for performance optimization
-			result[ 0 * BlockVolume.N2 + p ] = Vector512.Sum( Vector512.Multiply( input, coefficients[ 0 ] ) );
-			result[ 1 * BlockVolume.N2 + p ] = Vector512.Sum( Vector512.Multiply( input, coefficients[ 1 ] ) );
-			result[ 2 * BlockVolume.N2 + p ] = Vector512.Sum( Vector512.Multiply( input, coefficients[ 2 ] ) );
-			result[ 3 * BlockVolume.N2 + p ] = Vector512.Sum( Vector512.Multiply( input, coefficients[ 3 ] ) );
-			result[ 4 * BlockVolume.N2 + p ] = Vector512.Sum( Vector512.Multiply( input, coefficients[ 4 ] ) );
-			result[ 5 * BlockVolume.N2 + p ] = Vector512.Sum( Vector512.Multiply( input, coefficients[ 5 ] ) );
-			result[ 6 * BlockVolume.N2 + p ] = Vector512.Sum( Vector512.Multiply( input, coefficients[ 6 ] ) );
-			result[ 7 * BlockVolume.N2 + p ] = Vector512.Sum( Vector512.Multiply( input, coefficients[ 7 ] ) );
+			result[ 0 * BlockVolume.N2 + p ] = Vector512.Sum( input * coefficients[ 0 ] );
+			result[ 1 * BlockVolume.N2 + p ] = Vector512.Sum( input * coefficients[ 1 ] );
+			result[ 2 * BlockVolume.N2 + p ] = Vector512.Sum( input * coefficients[ 2 ] );
+			result[ 3 * BlockVolume.N2 + p ] = Vector512.Sum( input * coefficients[ 3 ] );
+			result[ 4 * BlockVolume.N2 + p ] = Vector512.Sum( input * coefficients[ 4 ] );
+			result[ 5 * BlockVolume.N2 + p ] = Vector512.Sum( input * coefficients[ 5 ] );
+			result[ 6 * BlockVolume.N2 + p ] = Vector512.Sum( input * coefficients[ 6 ] );
+			result[ 7 * BlockVolume.N2 + p ] = Vector512.Sum( input * coefficients[ 7 ] );
 
 			nonEmptyResultVectors |= 0x0101010101010101UL << ( p / BlockVolume.N );
 		}

--- a/src/PiWeb.Volume/Block/Quantization.cs
+++ b/src/PiWeb.Volume/Block/Quantization.cs
@@ -69,7 +69,7 @@ internal static class Quantization
 
 	private static bool TryGetQuantization( this IReadOnlyDictionary<string, string> options, [NotNullWhen( true )] out double[]? result )
 	{
-		result = default;
+		result = null;
 		if( !options.TryGetValue( BlockVolume.QuantizationName, out var quantizationString ) )
 			return false;
 
@@ -91,7 +91,7 @@ internal static class Quantization
 
 	private static bool TryGetDouble( this IReadOnlyDictionary<string, string> options, string name, out double value )
 	{
-		value = default;
+		value = 0;
 		return
 			options.TryGetValue( name, out var valueString ) &&
 			double.TryParse( valueString, NumberStyles.Float, CultureInfo.InvariantCulture, out value );

--- a/src/PiWeb.Volume/Block/ZigZag.cs
+++ b/src/PiWeb.Volume/Block/ZigZag.cs
@@ -57,7 +57,7 @@ internal static class ZigZag
 	/// <summary>
 	/// Reorders the buffer so the lower frequencies come first.
 	/// </summary>
-	public static void Apply( Span<double> values, Span<double> result )
+	public static void Apply( ReadOnlySpan<double> values, Span<double> result )
 	{
 		for( var i = 0; i < BlockVolume.N3; i++ )
 			result[ i ] = values[ Values[ i ] ];
@@ -66,7 +66,7 @@ internal static class ZigZag
 	/// <summary>
 	/// Reverses the order performed by the <see cref="Apply"/> method.
 	/// </summary>
-	public static void Reverse( Span<double> values, Span<double> result )
+	public static void Reverse( ReadOnlySpan<double> values, Span<double> result )
 	{
 		for( var i = 0; i < BlockVolume.N3; i++ )
 			result[ Values[ i ] ] = values[ i ];

--- a/src/PiWeb.Volume/Property.cs
+++ b/src/PiWeb.Volume/Property.cs
@@ -369,7 +369,7 @@ namespace Zeiss.PiWeb.Volume
 			}
 			catch( Exception )
 			{
-				result = default;
+				result = TimeSpan.Zero;
 				return false;
 			}
 		}


### PR DESCRIPTION
refactor: Use concrete default values instead of default expression
refactor: Improve code readability
refactor: Use nameof() for dependency property declaration