### PR TITLE
refactor: Unify and simplify project files using Directory.Build.props

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,55 @@
+<!--EXTERNAL_PROPERTIES: UseWpf-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <PropertyGroup>
+
+        <LangVersion>latestmajor</LangVersion>
+        <Platform>AnyCPU</Platform>
+        <TargetFramework>net9.0-windows10.0.22621</TargetFramework>
+        <RootNamespace Condition=" '$(RootNamespace)' == '' ">Zeiss.$(MSBuildProjectName)</RootNamespace>
+        <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+        <OutputPath>$(SolutionDir)\..\bin\$(Configuration)\</OutputPath>
+        <Configurations>Debug;Release;Test;Pack</Configurations>
+
+        <AssemblyTitle>Zeiss.$(MSBuildProjectName)</AssemblyTitle>
+        <Product>Zeiss.PiWeb.Volume</Product>
+        <Company>Carl Zeiss Industrielle Messtechnik GmbH</Company>
+        <Copyright>Copyright © 2025 Carl Zeiss Industrielle Messtechnik GmbH</Copyright>
+
+        <Authors>$(Company)</Authors>
+
+        <SelfContained>false</SelfContained>
+        <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+        <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+
+        <!-- Do not add target framework to output paths since we only build one flavor -->
+        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+
+        <!-- Disable default resource generation - we use our own patterns -->
+        <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
+
+        <!-- Prevent the error message: 'Ensure that this project has Microsoft.Bcl.Build installed and packages.config is located next to the project file.' -->
+        <SkipValidatePackageReferences>true</SkipValidatePackageReferences>
+
+        <!-- Enable nullable reference types for all projects -->
+        <Nullable>enable</Nullable>
+
+        <!-- Treat all warnings as errors -->
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+
+        <!-- Enforce to only use NuGets with compatible frameworks -->
+        <WarningsAsErrors>$(WarningsAsErrors);NU1701;NU1702</WarningsAsErrors>
+
+    </PropertyGroup>
+
+    <!-- Default includes and resource generation -->
+    <ItemGroup>
+        <EmbeddedResource Include="**/*.resx" />
+
+        <EmbeddedResource Update="**/*.resx">
+            <DependentUpon Condition="Exists('$([System.String]::Copy(&quot;%(RelativeDir)%(FileName)&quot;).Replace(&quot;.de&quot;, &quot;&quot;)).cs')">$([System.String]::Copy('%(FileName)').Replace('.de', '')).cs</DependentUpon>
+            <SubType>Designer</SubType>
+        </EmbeddedResource>
+    </ItemGroup>
+
+</Project>

--- a/src/PiWeb.Volume.Compare/PiWeb.Volume.Compare.csproj
+++ b/src/PiWeb.Volume.Compare/PiWeb.Volume.Compare.csproj
@@ -2,20 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>net9.0-windows10.0.22621</TargetFramework>
-    <Platform>AnyCPU</Platform>
-    <LangVersion>latestmajor</LangVersion>
-    <AssemblyName>PiWeb.Volume.Compare</AssemblyName>
-    <RootNamespace>Zeiss.PiWeb.Volume.Compare</RootNamespace>
-    <Copyright>Copyright © 2025 Carl Zeiss Industrielle Messtechnik GmbH</Copyright>
-    <Company>Carl Zeiss Industrielle Messtechnik GmbH</Company>
-    <Authors>$(Company)</Authors>
     <OutputType>WinExe</OutputType>
     <UseWPF>true</UseWPF>
     <IsPackable>false</IsPackable>
-    <OutputPath>$(SolutionDir)\..\bin\$(Configuration)\</OutputPath>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
-    <Configurations>Debug;Release;Test;Pack</Configurations>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/PiWeb.Volume.Convert/PiWeb.Volume.Convert.csproj
+++ b/src/PiWeb.Volume.Convert/PiWeb.Volume.Convert.csproj
@@ -1,25 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <Platform>AnyCPU</Platform>
-    <LangVersion>latestmajor</LangVersion>
-    <AssemblyName>PiWeb.Volume.Convert</AssemblyName>
-    <RootNamespace>Zeiss.PiWeb.Volume.Convert</RootNamespace>
-    <Copyright>Copyright © 2025 Carl Zeiss Industrielle Messtechnik GmbH</Copyright>
-    <Company>Carl Zeiss Industrielle Messtechnik GmbH</Company>
-    <Authors>$(Company)</Authors>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <IsPackable>false</IsPackable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
-    <OutputPath>$(SolutionDir)\..\bin\$(Configuration)\</OutputPath>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
-    <Configurations>Debug;Release;Test;Pack</Configurations>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/PiWeb.Volume.Tests/PiWeb.Volume.Tests.csproj
+++ b/src/PiWeb.Volume.Tests/PiWeb.Volume.Tests.csproj
@@ -1,17 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <Platform>AnyCPU</Platform>
-    <LangVersion>latestmajor</LangVersion>
-    <RootNamespace>Zeiss.PiWeb.Volume.Tests</RootNamespace>
     <IsPackable>false</IsPackable>
-    <OutputPath>$(SolutionDir)\..\bin\$(Configuration)\</OutputPath>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
-    <Configurations>Debug;Release;Test;Pack</Configurations>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/PiWeb.Volume.UI/PiWeb.Volume.UI.csproj
+++ b/src/PiWeb.Volume.UI/PiWeb.Volume.UI.csproj
@@ -1,22 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0-windows10.0.22621</TargetFramework>
-    <Platforms>AnyCPU</Platforms>
-    <LangVersion>latestmajor</LangVersion>
-    <AssemblyName>PiWeb.Volume.UI</AssemblyName>
-    <RootNamespace>Zeiss.PiWeb.Volume.UI</RootNamespace>
-    <Copyright>Copyright © 2025 Carl Zeiss Industrielle Messtechnik GmbH</Copyright>
-    <Company>Carl Zeiss Industrielle Messtechnik GmbH</Company>
-    <Authors>$(Company)</Authors>
     <UseWPF>true</UseWPF>
     <IsPackable>false</IsPackable>
-    <OutputPath>$(SolutionDir)\..\bin\$(Configuration)\</OutputPath>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
-    <Configurations>Debug;Release;Test;Pack</Configurations>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/PiWeb.Volume.Viewer/PiWeb.Volume.Viewer.csproj
+++ b/src/PiWeb.Volume.Viewer/PiWeb.Volume.Viewer.csproj
@@ -1,19 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Platform>AnyCPU</Platform>
     <OutputType>WinExe</OutputType>
-    <AssemblyName>PiWeb.Volume.Viewer</AssemblyName>
-    <RootNamespace>Zeiss.PiWeb.Volume.Viewer</RootNamespace>
-    <TargetFramework>net9.0-windows10.0.22621</TargetFramework>
     <UseWPF>true</UseWPF>
     <IsPackable>false</IsPackable>
-    <OutputPath>$(SolutionDir)\..\bin\$(Configuration)\</OutputPath>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
-    <Configurations>Debug;Release;Test;Pack</Configurations>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/PiWeb.Volume.sln
+++ b/src/PiWeb.Volume.sln
@@ -3,6 +3,11 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.32112.339
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{4C91B12E-F488-4A22-8AE3-D71D626EDDD5}"
+	ProjectSection(SolutionItems) = preProject
+		Directory.Build.props = Directory.Build.props
+	EndProjectSection
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PiWeb.Volume", "PiWeb.Volume\PiWeb.Volume.csproj", "{EE00A737-6B2B-4EE2-800F-21C8E7CB30E5}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PiWeb.Volume.Viewer", "PiWeb.Volume.Viewer\PiWeb.Volume.Viewer.csproj", "{990AFF9C-CA6F-4E61-8A67-C5C29184A0AC}"

--- a/src/PiWeb.Volume/PiWeb.Volume.csproj
+++ b/src/PiWeb.Volume/PiWeb.Volume.csproj
@@ -1,25 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <Platform>AnyCPU</Platform>
-    <LangVersion>latestmajor</LangVersion>
-    <AssemblyName>PiWeb.Volume</AssemblyName>
-    <RootNamespace>Zeiss.PiWeb.Volume</RootNamespace>
-    <Copyright>Copyright © 2025 Carl Zeiss Industrielle Messtechnik GmbH</Copyright>
-    <Company>Carl Zeiss Industrielle Messtechnik GmbH</Company>
-    <Authors>$(Company)</Authors>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
-    <OutputPath>..\..\bin\$(Configuration)\</OutputPath>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
-    <Configurations>Debug;Release;Test;Pack</Configurations>
-    <Nullable>enable</Nullable>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
@@ -47,15 +32,6 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>Carl Zeiss PiWeb Volume</PackageTags>
   </PropertyGroup>
-
-  <ItemGroup>
-    <EmbeddedResource Include="Volume.de.resx">
-      <DependentUpon>Volume.cs</DependentUpon>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Volume.resx">
-      <DependentUpon>Volume.cs</DependentUpon>
-    </EmbeddedResource>
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Zeiss.PiWeb.ColorScale" Version="1.0.0"/>


### PR DESCRIPTION
* We can reduce the contents of the csproj files by moving shared and identical code into the Directory.Build.props