### PR TITLE
chore: Bump .net version from 8.0 to 9.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
     - name: Build
       run: dotnet build ${{ github.workspace }}\src\PiWeb.Volume.sln
     - name: Test

--- a/.github/workflows/foss-compliance-scan.yml
+++ b/.github/workflows/foss-compliance-scan.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v1.1
       with:

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         source-url: https://api.nuget.org/v3/index.json
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
       env: 
         NUGET_AUTH_TOKEN: ${{secrets.NUGET_FEED_PAT}}
     - name: Setup MSBuild

--- a/src/PiWeb.Volume.sln
+++ b/src/PiWeb.Volume.sln
@@ -20,6 +20,14 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PiWeb.Volume.UI", "PiWeb.Vo
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PiWeb.Volume.Tests", "PiWeb.Volume.Tests\PiWeb.Volume.Tests.csproj", "{4A6F40F3-2B69-42AA-AF90-415D9AD94F23}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Workflows", "Workflows", "{86156BD6-86D6-4535-8F19-FC178097C3DA}"
+	ProjectSection(SolutionItems) = preProject
+		..\.github\workflows\build.yml = ..\.github\workflows\build.yml
+		..\.github\workflows\create-release.yml = ..\.github\workflows\create-release.yml
+		..\.github\workflows\foss-compliance-scan.yml = ..\.github\workflows\foss-compliance-scan.yml
+		..\.github\workflows\nuget-publish.yml = ..\.github\workflows\nuget-publish.yml
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64


### PR DESCRIPTION
* The current FOSS / SCA toolchain does not run when the library is built against .net 9 otherwise